### PR TITLE
feat: hardcode Bluesky OAuth config

### DIFF
--- a/main/api/bluesky-oauth.ts
+++ b/main/api/bluesky-oauth.ts
@@ -68,14 +68,18 @@ export const blueskyStartOAuth = async ({
     typeof app.isDefaultProtocolClient === "function"
       ? app.isDefaultProtocolClient(APP_PROTOCOL_SCHEME)
       : true;
+  const isPackaged = app.isPackaged;
 
   let redirectUriCandidate = redirectUri ?? env.redirectUri;
   if (
     redirectUriCandidate.startsWith(APP_PROTOCOL_PREFIX) &&
-    !isCustomSchemeRegistered &&
+    (!isPackaged || !isCustomSchemeRegistered) &&
     env.loopbackRedirectUri
   ) {
-    console.warn("[oauth] Custom scheme unavailable; falling back to loopback redirect URI");
+    console.warn("[oauth] Using loopback redirect URI in this environment", {
+      isPackaged,
+      isCustomSchemeRegistered,
+    });
     redirectUriCandidate = env.loopbackRedirectUri;
   }
   const redirectUriParseResult = oauthRedirectUriSchema.safeParse(redirectUriCandidate);

--- a/main/oauth/constants.ts
+++ b/main/oauth/constants.ts
@@ -1,5 +1,9 @@
-export const APP_PROTOCOL_SCHEME = "io.github.nekobato";
+import { BLUESKY_REDIRECT_URI } from "../../shared/bluesky-oauth";
+
+const redirectUriUrl = new URL(BLUESKY_REDIRECT_URI);
+
+export const APP_PROTOCOL_SCHEME = redirectUriUrl.protocol.replace(":", "");
 export const APP_PROTOCOL_PREFIX = `${APP_PROTOCOL_SCHEME}:/`;
 
-export const BLUESKY_CUSTOM_REDIRECT_URI = `${APP_PROTOCOL_PREFIX}oauth/bluesky/callback`;
+export const BLUESKY_CUSTOM_REDIRECT_URI = BLUESKY_REDIRECT_URI;
 export const APP_LOOPBACK_REDIRECT_URI = "http://127.0.0.1:17600/callback";

--- a/shared/bluesky-oauth.ts
+++ b/shared/bluesky-oauth.ts
@@ -1,0 +1,16 @@
+/**
+ * Public Bluesky OAuth client metadata URL.
+ * This value is not secret and is intended to be embedded in the app.
+ */
+export const BLUESKY_CLIENT_ID = "https://nekobato.github.io/DotE/bluesky-client-metadata.json";
+
+/**
+ * Spec-compliant custom scheme redirect URI for the native desktop app.
+ */
+export const BLUESKY_REDIRECT_URI = "io.github.nekobato:/oauth/bluesky/callback";
+
+/**
+ * Minimal Bluesky OAuth scope used by this application.
+ */
+export const BLUESKY_SCOPE = "atproto transition:generic";
+

--- a/shared/types/store.d.ts
+++ b/shared/types/store.d.ts
@@ -121,8 +121,12 @@ export type Settings = {
     hideCw: boolean;
     showReactions: boolean;
   };
-  bluesky: {
-    oauth: {
+  /**
+   * Legacy Bluesky OAuth settings.
+   * These values are now hard-coded and any persisted settings are ignored.
+   */
+  bluesky?: {
+    oauth?: {
       clientId: string;
       redirectUri: string;
       scope: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -75,13 +75,6 @@ const initialSettings: Settings = {
     hideCw: false,
     showReactions: true,
   },
-  bluesky: {
-    oauth: {
-      clientId: "",
-      redirectUri: "io.github.nekobato:/oauth/bluesky/callback",
-      scope: "atproto transition:generic",
-    },
-  },
 };
 
 // DBから取得した生データ全て


### PR DESCRIPTION
## Summary
- Hardcode Bluesky OAuth clientId, redirectUri, and scope in shared constants.
- Stop reading Bluesky OAuth values from persisted settings.
- Derive protocol scheme from the redirect URI constant in the main process.
- Use loopback redirect URI automatically in dev/unpackaged runs.
- Remove legacy settings cleanup (values are simply ignored now).

## Testing
- pnpm typecheck