### PR TITLE
fix: refresh missing Misskey reaction emojis (#269)

### DIFF
--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -40,7 +40,6 @@ export function useStream() {
           break;
         case "unreacted":
           await misskeyStore.removeReaction({ postId: data.id, reaction: data.body.reaction });
-          misskeyStore.ensureReactionEmoji({ postId: data.id, reaction: data.body.reaction });
           break;
         default:
           console.warn("unhandled noteUpdated", data);

--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -36,9 +36,11 @@ export function useStream() {
       switch (event) {
         case "reacted":
           await misskeyStore.addReaction({ postId: data.id, reaction: data.body.reaction });
+          misskeyStore.ensureReactionEmoji({ postId: data.id, reaction: data.body.reaction });
           break;
         case "unreacted":
           await misskeyStore.removeReaction({ postId: data.id, reaction: data.body.reaction });
+          misskeyStore.ensureReactionEmoji({ postId: data.id, reaction: data.body.reaction });
           break;
         default:
           console.warn("unhandled noteUpdated", data);


### PR DESCRIPTION
## 背景
Issue #269: Misskey のリアクションで remote emoji の画像が欠けることがあるため、必要時にノートを再取得して補完します。

## 変更点
- 反応更新後に「emoji が欠けている場合のみ」ノート再取得をスケジュールします（デバウンスあり）。
- 再取得は userId/instance/token を保持して行い、タイムライン切替の影響を避けます。
- 取得結果は #228 の共通ヘルパーで全 timeline に反映します。

## 動作確認
- 実行: pnpm typecheck
- 結果: 成功

## 補足
- カスタム emoji（`:` で始まるリアクション）のみ補完対象にしています。
