### PR TITLE
feat: add light theme

### DIFF
--- a/main/db.ts
+++ b/main/db.ts
@@ -44,6 +44,7 @@ export const storeDefaults: StoreSchema = {
   settings: {
     opacity: 50,
     mode: "show",
+    theme: "dark",
     font: {
       family: "",
     },
@@ -132,6 +133,7 @@ const schema: Schema<StoreSchema> = {
     properties: {
       opacity: { type: "number" },
       mode: { type: "string" },
+      theme: { type: "string" },
       font: {
         type: "object",
         properties: {
@@ -462,6 +464,8 @@ export const setSetting = (key: string, value: any) => {
       return store.set("settings.opacity", Number(value));
     case "mode":
       return store.set("settings.mode", value);
+    case "theme":
+      return store.set("settings.theme", value);
     case "windowSize":
       return store.set("settings.windowSize", value);
     case "font.family":

--- a/shared/types/store.d.ts
+++ b/shared/types/store.d.ts
@@ -97,6 +97,7 @@ export type LineStyle = "all" | "line-1" | "line-2" | "line-3";
 export type Settings = {
   opacity: number;
   mode: "show" | "haze" | "hide" | "settings" | "tutorial";
+  theme: "dark" | "light";
   font: {
     family: string;
   };

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ const applyTheme = (value: Settings["theme"]) => {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
   root.dataset.theme = value;
+  // Element Plus uses html.dark for its dark theme variables.
   root.classList.toggle("dark", value === "dark");
   root.style.colorScheme = value;
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,30 @@
 <script lang="ts" setup>
-import { useStorage } from "@vueuse/core";
-import { onMounted } from "vue";
+import { useStore } from "@/store";
+import type { Settings } from "@shared/types/store";
+import { computed, onMounted, watch } from "vue";
 import { RouterView } from "vue-router";
 
-const theme = useStorage("theme", "default");
+const store = useStore();
+const theme = computed<Settings["theme"]>(() => store.settings?.theme ?? "dark");
+
+/**
+ * Apply the selected theme to the document root.
+ */
+const applyTheme = (value: Settings["theme"]) => {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.dataset.theme = value;
+  root.classList.toggle("dark", value === "dark");
+  root.style.colorScheme = value;
+};
+
+watch(
+  theme,
+  (value) => {
+    applyTheme(value);
+  },
+  { immediate: true },
+);
 
 onMounted(() => {
   console.info("[App] mounted", { theme: theme.value });

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -12,7 +12,7 @@ body {
 }
 
 h1 {
-  color: #bababa;
+  color: var(--color-text-title);
   font-size: 3.2em;
   line-height: 1.1;
 }
@@ -20,7 +20,7 @@ h1 {
 button,
 input {
   outline-width: 2;
-  outline-color: #fff;
+  outline-color: var(--dote-color-white);
 }
 
 .dote-unvisible {
@@ -30,7 +30,7 @@ input {
 .dote-field-group-title {
   display: block;
   padding: 8px 16px 0px;
-  color: #bababa;
+  color: var(--color-text-title);
   font-weight: bold;
   font-size: 1rem;
 
@@ -83,6 +83,6 @@ input {
     margin-bottom: -2px;
   }
   a {
-    color: #efefef;
+    color: var(--color-text-link);
   }
 }

--- a/src/assets/styles/button.scss
+++ b/src/assets/styles/button.scss
@@ -24,8 +24,8 @@ button {
   text-align: center;
   text-decoration: none;
   word-break: break-word;
-  background: rgba(255, 255, 255, 0);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  border: 1px solid var(--dote-color-white-t2);
   border-radius: 4px;
   cursor: pointer;
   transition-property: background-color, border-color, color, fill;
@@ -144,13 +144,13 @@ button {
     fill: var(--color-button-text);
     &:hover,
     &:focus {
-      color: #fff;
-      background: rgba(255, 255, 255, 0.1);
+      color: var(--dote-color-white);
+      background: var(--dote-color-white-t1);
     }
 
     &:active {
-      color: #fff;
-      background: rgba(255, 255, 255, 0.2);
+      color: var(--dote-color-white);
+      background: var(--dote-color-white-t2);
     }
 
     &[disabled] {
@@ -169,7 +169,7 @@ button {
   cursor: pointer;
   &:hover {
     svg {
-      fill: #dddddd;
+      fill: var(--dote-color-white);
     }
   }
 }

--- a/src/assets/styles/form.scss
+++ b/src/assets/styles/form.scss
@@ -17,7 +17,7 @@
 
 label.nn-label {
   display: block;
-  color: rgba(255,255,255, 0.72);
+  color: var(--dote-color-white-t4);
   font-weight: bold;
   font-size: 14px;
   line-height: 1;
@@ -33,16 +33,16 @@ textarea.nn-text-field {
   height: 24px;
   margin: 0;
   padding: 2px 8px;
-  color: #ffffff;
+  color: var(--color-text-input);
   font-weight: normal;
   font-size: 16px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: var(--dote-color-white-t1);
+  border: 1px solid var(--dote-color-white-t3);
   border-radius: 4px;
   -webkit-appearance: textfield;
 
   &:focus {
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--dote-color-white-t2);
   }
 }
 
@@ -123,7 +123,7 @@ textarea.nn-text-field {
     width: 20px;
     height: 20px;
     margin: 0;
-    border: 2px solid #bdbdbd;
+    border: 2px solid var(--dote-color-white-t3);
     border-radius: 4px;
     cursor: pointer;
   }

--- a/src/assets/styles/icon.scss
+++ b/src/assets/styles/icon.scss
@@ -2,7 +2,7 @@
   display: inline-flex;
   width: 24px;
   height: 24px;
-  fill: #ffffff;
+  fill: var(--dote-color-white);
 
   &.size-large {
     width: 32px;
@@ -24,11 +24,11 @@
   }
 
   &.secondary {
-    fill: #999999;
+    fill: var(--dote-color-white-t4);
   }
 
   &.disabled {
-    fill: #cccccc;
+    fill: var(--dote-color-white-t2);
   }
 
   &.accent {

--- a/src/assets/styles/reset.scss
+++ b/src/assets/styles/reset.scss
@@ -27,7 +27,7 @@ dd {
 }
 
 html {
-  color: #ffffff;
+  color: var(--color-text-body);
   font-weight: normal;
   font-size: 20px;
   font-family:  Roboto, 'Segoe UI', 'Helvetica Neue', "Hiragino Kaku Gothic Pro", "Hiragino Sans", Meiryo, sans-serif;

--- a/src/assets/styles/theme/default.scss
+++ b/src/assets/styles/theme/default.scss
@@ -1,6 +1,6 @@
-.theme.default {
+.theme {
   /* Post Body */
   --post-body--font-size: 0.6rem;
   --post-body--line-height: 0.8rem;
-  --post-body-color: #efefef;
+  --post-body-color: var(--color-text-body);
 }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -1,4 +1,4 @@
-:root{
+:root {
   --layout-w-pc: 1080px;
   --layout-w-tablet: 768px;
   --layout-w-mobile: 480px;
@@ -12,7 +12,10 @@
   --font-size-20: 1rem;
   --font-size-24: 1.2rem;
   --font-size-32: 1.6rem;
+}
 
+:root,
+:root[data-theme="dark"] {
   --color-foreground: #1e1e1e;
   --color-background: #252522;
   --color-gutter: #1D2025;
@@ -37,6 +40,7 @@
   --color-text-link-active: #e5e5e5;
   --color-text-input: #e5e5e5;
   --color-text-input-placeholder: #e5e5e5;
+  --color-text-code: #e5e5e5;
 
   --dote-color-white: #e5e5e5;
   --dote-color-black: #000000;
@@ -50,6 +54,57 @@
   --dote-color-white-t3: rgba(255, 255, 255, 0.48);
   --dote-color-white-t4: rgba(255, 255, 255, 0.64);
   --dote-color-white-t5: rgba(255, 255, 255, 0.8);
+
+  --dote-color-black-t1: rgba(0, 0, 0, 0.08);
+  --dote-color-black-t2: rgba(0, 0, 0, 0.32);
+  --dote-color-black-t3: rgba(0, 0, 0, 0.48);
+  --dote-color-black-t4: rgba(0, 0, 0, 0.64);
+  --dote-color-black-t5: rgba(0, 0, 0, 0.8);
+
+  /* Tokens */
+  --dote-background-color: var(--color-background);
+  --dote-border-color: var(--dote-color-white-t1);
+}
+
+:root[data-theme="light"] {
+  --color-foreground: #ffffff;
+  --color-background: #f6f6f2;
+  --color-gutter: #e8e7e2;
+  --color-guide: #666666;
+  --color-accent: #528BFF;
+  --color-text: #1f2328;
+  --color-cyan: #56B6C2;
+  --color-blue: #2f6bff;
+  --color-purple: #C678DD;
+  --color-green: #4d9f6e;
+  --color-rose: #E06C75;
+  --color-orange: #D19A66;
+  --color-red: #BE5046;
+  --color-gold: #C69235;
+
+  --color-text-body: #1f2328;
+  --color-text-title: #1f2328;
+  --color-text-subtitle: #4b4b4b;
+  --color-text-caption: #5c5c5c;
+  --color-text-link: #2f6bff;
+  --color-text-link-hover: #1f57d0;
+  --color-text-link-active: #1441a3;
+  --color-text-input: #1f2328;
+  --color-text-input-placeholder: #7a7a7a;
+  --color-text-code: #1f2328;
+
+  --dote-color-white: #1f2328;
+  --dote-color-black: #000000;
+  --dote-color-info: #909399;
+  --dote-color-success: #67c23a;
+  --dote-color-warning: #e6a23c;
+  --dote-color-error: #f56c6c;
+
+  --dote-color-white-t1: rgba(0, 0, 0, 0.08);
+  --dote-color-white-t2: rgba(0, 0, 0, 0.32);
+  --dote-color-white-t3: rgba(0, 0, 0, 0.48);
+  --dote-color-white-t4: rgba(0, 0, 0, 0.64);
+  --dote-color-white-t5: rgba(0, 0, 0, 0.8);
 
   --dote-color-black-t1: rgba(0, 0, 0, 0.08);
   --dote-color-black-t2: rgba(0, 0, 0, 0.32);

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -42,18 +42,27 @@
   --color-text-input-placeholder: #e5e5e5;
   --color-text-code: #e5e5e5;
 
-  --dote-color-white: #e5e5e5;
+  --dote-color-ink: #e5e5e5;
+  /* Deprecated alias; prefer --dote-color-ink */
+  --dote-color-white: var(--dote-color-ink);
   --dote-color-black: #000000;
   --dote-color-info: #909399;
   --dote-color-success: #67c23a;
   --dote-color-warning: #e6a23c;
   --dote-color-error: #f56c6c;
 
-  --dote-color-white-t1: rgba(255, 255, 255, 0.08);
-  --dote-color-white-t2: rgba(255, 255, 255, 0.32);
-  --dote-color-white-t3: rgba(255, 255, 255, 0.48);
-  --dote-color-white-t4: rgba(255, 255, 255, 0.64);
-  --dote-color-white-t5: rgba(255, 255, 255, 0.8);
+  --dote-color-ink-t1: rgba(255, 255, 255, 0.08);
+  --dote-color-ink-t2: rgba(255, 255, 255, 0.32);
+  --dote-color-ink-t3: rgba(255, 255, 255, 0.48);
+  --dote-color-ink-t4: rgba(255, 255, 255, 0.64);
+  --dote-color-ink-t5: rgba(255, 255, 255, 0.8);
+
+  /* Deprecated alias; prefer --dote-color-ink-t* */
+  --dote-color-white-t1: var(--dote-color-ink-t1);
+  --dote-color-white-t2: var(--dote-color-ink-t2);
+  --dote-color-white-t3: var(--dote-color-ink-t3);
+  --dote-color-white-t4: var(--dote-color-ink-t4);
+  --dote-color-white-t5: var(--dote-color-ink-t5);
 
   --dote-color-black-t1: rgba(0, 0, 0, 0.08);
   --dote-color-black-t2: rgba(0, 0, 0, 0.32);
@@ -63,7 +72,7 @@
 
   /* Tokens */
   --dote-background-color: var(--color-background);
-  --dote-border-color: var(--dote-color-white-t1);
+  --dote-border-color: var(--dote-color-ink-t1);
 }
 
 :root[data-theme="light"] {
@@ -93,18 +102,27 @@
   --color-text-input-placeholder: #7a7a7a;
   --color-text-code: #1f2328;
 
-  --dote-color-white: #1f2328;
+  --dote-color-ink: #1f2328;
+  /* Deprecated alias; prefer --dote-color-ink */
+  --dote-color-white: var(--dote-color-ink);
   --dote-color-black: #000000;
   --dote-color-info: #909399;
   --dote-color-success: #67c23a;
   --dote-color-warning: #e6a23c;
   --dote-color-error: #f56c6c;
 
-  --dote-color-white-t1: rgba(0, 0, 0, 0.08);
-  --dote-color-white-t2: rgba(0, 0, 0, 0.32);
-  --dote-color-white-t3: rgba(0, 0, 0, 0.48);
-  --dote-color-white-t4: rgba(0, 0, 0, 0.64);
-  --dote-color-white-t5: rgba(0, 0, 0, 0.8);
+  --dote-color-ink-t1: rgba(31, 35, 40, 0.08);
+  --dote-color-ink-t2: rgba(31, 35, 40, 0.32);
+  --dote-color-ink-t3: rgba(31, 35, 40, 0.48);
+  --dote-color-ink-t4: rgba(31, 35, 40, 0.64);
+  --dote-color-ink-t5: rgba(31, 35, 40, 0.8);
+
+  /* Deprecated alias; prefer --dote-color-ink-t* */
+  --dote-color-white-t1: var(--dote-color-ink-t1);
+  --dote-color-white-t2: var(--dote-color-ink-t2);
+  --dote-color-white-t3: var(--dote-color-ink-t3);
+  --dote-color-white-t4: var(--dote-color-ink-t4);
+  --dote-color-white-t5: var(--dote-color-ink-t5);
 
   --dote-color-black-t1: rgba(0, 0, 0, 0.08);
   --dote-color-black-t2: rgba(0, 0, 0, 0.32);
@@ -114,5 +132,5 @@
 
   /* Tokens */
   --dote-background-color: var(--color-background);
-  --dote-border-color: var(--dote-color-white-t1);
+  --dote-border-color: var(--dote-color-ink-t1);
 }

--- a/src/components/PostItem/BlueskyPost.vue
+++ b/src/components/PostItem/BlueskyPost.vue
@@ -264,7 +264,7 @@ const deleteLike = () => {
 .text-container {
   min-height: calc(0.8rem * 2);
   overflow: hidden;
-  color: #efefef;
+  color: var(--dote-color-white);
   font-size: 0.6rem;
   line-height: 0.8rem;
 }

--- a/src/components/PostItem/BlueskyPostContent.vue
+++ b/src/components/PostItem/BlueskyPostContent.vue
@@ -209,7 +209,7 @@ const openOriginPage = () => {
 .text-container {
   min-height: calc(0.8rem * 2);
   overflow: hidden;
-  color: #efefef;
+  color: var(--dote-color-white);
   font-size: 0.6rem;
   line-height: 0.8rem;
 }

--- a/src/components/PostItem/MastodonNotification.vue
+++ b/src/components/PostItem/MastodonNotification.vue
@@ -270,7 +270,7 @@ const openUserPage = (user: MastodonToot["account"]) => {
   .text-container {
     min-height: calc(0.8rem * 2);
     overflow: hidden;
-    color: #efefef;
+    color: var(--dote-color-white);
     font-size: 0.6rem;
     line-height: 1rem;
   }
@@ -279,7 +279,7 @@ const openUserPage = (user: MastodonToot["account"]) => {
     display: flex;
     align-items: center;
     min-height: calc(0.8rem * 2);
-    color: #efefef;
+    color: var(--dote-color-white);
     font-size: 0.6rem;
     line-height: 0.8rem;
   }

--- a/src/components/PostItem/MastodonToot.vue
+++ b/src/components/PostItem/MastodonToot.vue
@@ -346,7 +346,7 @@ const openUserPage = (user: MastodonToot["account"]) => {
   .text-container {
     min-height: calc(0.8rem * 2);
     overflow: hidden;
-    color: #efefef;
+    color: var(--dote-color-white);
     font-size: 0.6rem;
     line-height: 1rem;
   }

--- a/src/components/PostItem/MisskeyNoteContent.vue
+++ b/src/components/PostItem/MisskeyNoteContent.vue
@@ -234,7 +234,7 @@ const lineClass = computed(() => {
 .text-container {
   min-height: calc(0.8rem * 2);
   overflow: hidden;
-  color: #efefef;
+  color: var(--dote-color-white);
   font-size: 0.6rem;
   line-height: 1rem;
 }

--- a/src/components/PostItem/MisskeyNotificationContent.vue
+++ b/src/components/PostItem/MisskeyNotificationContent.vue
@@ -196,7 +196,7 @@ const openUserPage = (user: MisskeyNote["user"]) => {
   align-items: center;
   min-height: calc(0.8rem * 2);
   overflow: hidden;
-  color: #efefef;
+  color: var(--dote-color-white);
   font-size: 0.6rem;
   line-height: 1rem;
 }

--- a/src/components/Settings/AccountSettings.vue
+++ b/src/components/Settings/AccountSettings.vue
@@ -149,7 +149,7 @@ const closeAddAccount = () => {
 }
 .content {
   padding: 4px 0;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
   .account-input {
     width: 200px;
@@ -161,12 +161,12 @@ const closeAddAccount = () => {
     height: 16px;
   }
   &:hover {
-    background: rgba(255, 255, 255, 0.4);
+    background: var(--dote-color-ink-t2);
   }
 }
 .add-account-hint {
   margin-left: 8px;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--color-text-caption);
   font-size: var(--font-size-12);
 }
 </style>

--- a/src/components/Settings/AddAccountBluesky.vue
+++ b/src/components/Settings/AddAccountBluesky.vue
@@ -114,7 +114,7 @@ const startOAuth = async () => {
 <style lang="scss" scoped>
 .content {
   padding: 4px 0;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
   .account-input {
     width: 220px;
@@ -122,20 +122,20 @@ const startOAuth = async () => {
 }
 .description {
   margin: 0 0 8px;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--color-text-subtitle);
 }
 .hint {
   margin: 4px 0 8px;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--color-text-caption);
   font-size: var(--font-size-12);
   span {
-    color: #fff;
+    color: var(--color-text-body);
     font-weight: 600;
   }
 }
 .info {
   margin: 0 0 8px;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--color-text-caption);
   font-size: var(--font-size-12);
 }
 .config-warning {
@@ -149,7 +149,7 @@ const startOAuth = async () => {
     height: 16px;
   }
   &:hover {
-    background: rgba(255, 255, 255, 0.4);
+    background: var(--dote-color-ink-t2);
   }
 }
 </style>

--- a/src/components/Settings/AddAccountMastodon.vue
+++ b/src/components/Settings/AddAccountMastodon.vue
@@ -133,7 +133,7 @@ const fetchAndSetMastodonMyself = async (token: string) => {
 <style lang="scss" scoped>
 .content {
   padding: 4px 0;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
   .account-input {
     width: 200px;
@@ -145,7 +145,7 @@ const fetchAndSetMastodonMyself = async (token: string) => {
     height: 16px;
   }
   &:hover {
-    background: rgba(255, 255, 255, 0.4);
+    background: var(--dote-color-ink-t2);
   }
 }
 </style>

--- a/src/components/Settings/AddAccountMisskey.vue
+++ b/src/components/Settings/AddAccountMisskey.vue
@@ -115,7 +115,7 @@ const openMisskeyAuthLink = () => {
 }
 .content {
   padding: 4px 0;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
   .account-input {
     width: 200px;
@@ -127,7 +127,7 @@ const openMisskeyAuthLink = () => {
     height: 16px;
   }
   &:hover {
-    background: rgba(255, 255, 255, 0.4);
+    background: var(--dote-color-ink-t2);
   }
 }
 </style>

--- a/src/components/Settings/ApplicationInformation.vue
+++ b/src/components/Settings/ApplicationInformation.vue
@@ -27,7 +27,7 @@ import { information } from "@/store/information";
   align-items: center;
   width: 100%;
   padding: 4px 0;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
   .title {
     display: inline-flex;

--- a/src/components/Settings/ApplicationSettings.vue
+++ b/src/components/Settings/ApplicationSettings.vue
@@ -66,8 +66,26 @@ const postStyleOptions = [
   },
 ];
 
+const themeOptions = [
+  {
+    label: "ダーク",
+    value: "dark",
+  },
+  {
+    label: "ライト",
+    value: "light",
+  },
+];
+
 const onChangePostStyle = (value: string | number | boolean) => {
   settingsStore.setPostStyle(value as Settings["postStyle"]);
+};
+
+/**
+ * Persist selected theme in settings.
+ */
+const onChangeTheme = (value: string | number | boolean) => {
+  settingsStore.setTheme(value as Settings["theme"]);
 };
 
 const focusShortcutInput = () => {
@@ -108,6 +126,17 @@ const onChangeText2Speech = async (value: string | number | boolean) => {
       </div>
       <div class="actions">
         <ElSlider v-model="store.settings.opacity" :min="0" :max="100" show-input size="small" />
+      </div>
+    </div>
+
+    <div class="dote-field-row indent-1">
+      <div class="content">
+        <span class="title">テーマ</span>
+      </div>
+      <div class="form-actions">
+        <ElSelect class="action-field" :model-value="store.settings.theme" size="small" @change="onChangeTheme">
+          <ElOption v-for="option in themeOptions" :key="option.value" :label="option.label" :value="option.value" />
+        </ElSelect>
       </div>
     </div>
 

--- a/src/components/Settings/TimelineForm.vue
+++ b/src/components/Settings/TimelineForm.vue
@@ -392,7 +392,7 @@ onMounted(() => {
 .content {
   display: inline-flex;
   align-items: center;
-  color: #fff;
+  color: var(--color-text-body);
   font-size: var(--font-size-14);
 
   & > * {

--- a/src/components/TimelineHeader.vue
+++ b/src/components/TimelineHeader.vue
@@ -237,9 +237,6 @@ const getChannelLabel = (channel: MisskeyChannelName | MastodonChannelName | Blu
   align-items: center;
   justify-content: flex-start;
   padding: 7px 0 9px; /* for appearance */
-  box-shadow:
-    rgba(50, 50, 93, 0.25) 0px 13px 27px -5px,
-    rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
   -webkit-app-region: no-drag;
 
   &.detailed {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -51,6 +51,7 @@ type RootState = {
 const initialSettings: Settings = {
   opacity: 50,
   mode: "show",
+  theme: "dark",
   font: {
     family: "",
   },

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -16,6 +16,14 @@ export const useSettingsStore = defineStore("settings", () => {
     return await ipcInvoke("settings:set", { key: "mode", value: mode });
   };
 
+  /**
+   * Persist selected theme (dark or light).
+   */
+  const setTheme = async (theme: Settings["theme"]) => {
+    store.$state.settings.theme = theme;
+    return await ipcInvoke("settings:set", { key: "theme", value: theme });
+  };
+
   const setMaxPostCount = async (count: number) => {
     store.$state.settings.maxPostCount = count;
     return await ipcInvoke("settings:set", { key: "maxPostCount", value: count.toString() });
@@ -64,6 +72,7 @@ export const useSettingsStore = defineStore("settings", () => {
   return {
     setOpacity,
     setMode,
+    setTheme,
     setMaxPostCount,
     setFontFamily,
     setPostStyle,


### PR DESCRIPTION
## Summary
- add theme setting persisted in store and apply it to the document root
- add theme selector in application settings
- add light theme css variables and replace key hard-coded colors with tokens

## Testing
- not run (no test/lint/format scripts in package.json)
