### PR TITLE
feat: shrink avatars in line-1 view

### DIFF
--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -11,6 +11,22 @@ body {
   height: 100%;
 }
 
+.dote-post-content {
+  --post-avatar-size: 32px;
+  --post-avatar-mini-size: 20px;
+  --post-avatar-mini-offset: 28px;
+  --post-avatar-origin-size: 20px;
+  --post-avatar-origin-offset: 12px;
+
+  &.line-1 {
+    --post-avatar-size: var(--post-body--line-height);
+    --post-avatar-mini-size: var(--font-size-12);
+    --post-avatar-mini-offset: calc(var(--post-avatar-size) - 4px);
+    --post-avatar-origin-size: var(--font-size-12);
+    --post-avatar-origin-offset: calc(var(--post-avatar-size) / 2 - 4px);
+  }
+}
+
 h1 {
   color: #bababa;
   font-size: 3.2em;

--- a/src/components/PostItem/BlueskyPostContent.vue
+++ b/src/components/PostItem/BlueskyPostContent.vue
@@ -212,36 +212,36 @@ const openOriginPage = () => {
   color: #efefef;
   font-size: 0.6rem;
   line-height: 0.8rem;
-}
 
-.line-all {
-  display: block;
-  .cw,
-  .text {
+  &.line-all {
     display: block;
+    .cw,
+    .text {
+      display: block;
+    }
   }
-}
-.line-1,
-.line-2,
-.line-3 {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  .cw,
-  .text {
-    display: inline;
-  }
+  &.line-1,
+  &.line-2,
+  &.line-3 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    .cw,
+    .text {
+      display: inline;
+    }
 
-  .cw + * {
-    margin-left: 8px;
+    .cw + * {
+      margin-left: 8px;
+    }
   }
-}
-.line-1 {
-  line-clamp: 1;
-}
-.line-2 {
-  line-clamp: 2;
-}
-.line-3 {
-  line-clamp: 3;
+  &.line-1 {
+    -webkit-line-clamp: 1;
+  }
+  &.line-2 {
+    -webkit-line-clamp: 2;
+  }
+  &.line-3 {
+    -webkit-line-clamp: 3;
+  }
 }
 </style>

--- a/src/components/PostItem/BlueskyPostContent.vue
+++ b/src/components/PostItem/BlueskyPostContent.vue
@@ -84,7 +84,7 @@ const openOriginPage = () => {
         />
       </div>
     </div>
-    <div class="dote-post-content">
+    <div class="dote-post-content" :class="[props.lineStyle]">
       <img class="dote-avatar" :src="author.avatar || ''" alt="" @click="openUserPage" />
       <img
         class="dote-avatar origin-user"
@@ -115,8 +115,8 @@ const openOriginPage = () => {
 
 .dote-avatar {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
+  width: var(--post-avatar-size);
+  height: var(--post-avatar-size);
   margin: 0 0 auto 0;
   object-fit: cover;
   overflow: hidden;
@@ -124,18 +124,18 @@ const openOriginPage = () => {
   border-radius: 50%;
   &.mini {
     position: relative;
-    top: 28px;
+    top: var(--post-avatar-mini-offset);
     z-index: 1;
-    width: 20px;
-    height: 20px;
+    width: var(--post-avatar-mini-size);
+    height: var(--post-avatar-mini-size);
   }
 
   &.origin-user {
     position: absolute;
-    top: 12px;
+    top: var(--post-avatar-origin-offset);
     left: 0;
-    width: 20px;
-    height: 20px;
+    width: var(--post-avatar-origin-size);
+    height: var(--post-avatar-origin-size);
     margin-left: 0;
   }
 
@@ -202,8 +202,8 @@ const openOriginPage = () => {
 }
 
 .dote-post-info .renote > .dote-post-body > .dote-avatar {
-  width: 20px;
-  height: 20px;
+  width: var(--post-avatar-mini-size);
+  height: var(--post-avatar-mini-size);
 }
 
 .text-container {

--- a/src/components/PostItem/MastodonNotification.vue
+++ b/src/components/PostItem/MastodonNotification.vue
@@ -81,7 +81,7 @@ const openUserPage = (user: MastodonToot["account"]) => {
             }}</span>
           </div>
         </div>
-        <div class="dote-post-content">
+        <div class="dote-post-content" :class="[lineStyle]">
           <img
             v-if="props.post || props.by"
             class="dote-avatar"
@@ -216,8 +216,8 @@ const openUserPage = (user: MastodonToot["account"]) => {
 
   .dote-avatar {
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: var(--post-avatar-size);
+    height: var(--post-avatar-size);
     margin: 0 0 auto 0;
     object-fit: cover;
     overflow: hidden;
@@ -225,11 +225,11 @@ const openUserPage = (user: MastodonToot["account"]) => {
     border-radius: 50%;
     &.mini {
       position: absolute;
-      top: 32px;
+      top: var(--post-avatar-mini-offset);
       left: 0;
       z-index: 1;
-      width: 20px;
-      height: 20px;
+      width: var(--post-avatar-mini-size);
+      height: var(--post-avatar-mini-size);
     }
 
     & + * {

--- a/src/components/PostItem/MastodonNotification.vue
+++ b/src/components/PostItem/MastodonNotification.vue
@@ -308,13 +308,13 @@ const openUserPage = (user: MastodonToot["account"]) => {
   .line-1 {
     min-height: 0.8rem;
     white-space: nowrap;
-    line-clamp: 1;
+    -webkit-line-clamp: 1;
   }
   .line-2 {
-    line-clamp: 2;
+    -webkit-line-clamp: 2;
   }
   .line-3 {
-    line-clamp: 3;
+    -webkit-line-clamp: 3;
   }
 }
 </style>

--- a/src/components/PostItem/MastodonToot.vue
+++ b/src/components/PostItem/MastodonToot.vue
@@ -97,10 +97,10 @@ const openUserPage = (user: MastodonToot["account"]) => {
             }}</span>
           </div>
         </div>
-        <div class="dote-post-content">
+        <div class="dote-post-content" :class="[props.lineStyle]">
           <img
             class="dote-avatar"
-            :class="{ mini: postType === 'reblog', 'line-1': props.lineStyle === 'line-1' }"
+            :class="{ mini: postType === 'reblog' }"
             :src="props.post.account.avatar || ''"
             alt=""
             @click="openUserPage(post.account)"
@@ -284,29 +284,19 @@ const openUserPage = (user: MastodonToot["account"]) => {
 
   .dote-avatar {
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: var(--post-avatar-size);
+    height: var(--post-avatar-size);
     margin: 0 0 auto 0;
     object-fit: cover;
     overflow: hidden;
     border: 1px solid rgba(255, 255, 255, 0.24);
     border-radius: 50%;
-    &.line-1 {
-      width: 20px;
-      height: 20px;
-
-      &.mini {
-        top: 24px;
-        width: 16px;
-        height: 16px;
-      }
-    }
     &.mini {
       position: relative;
-      top: 28px;
+      top: var(--post-avatar-mini-offset);
       z-index: 1;
-      width: 20px;
-      height: 20px;
+      width: var(--post-avatar-mini-size);
+      height: var(--post-avatar-mini-size);
     }
 
     & + * {

--- a/src/components/PostItem/MastodonToot.vue
+++ b/src/components/PostItem/MastodonToot.vue
@@ -339,39 +339,39 @@ const openUserPage = (user: MastodonToot["account"]) => {
     color: #efefef;
     font-size: 0.6rem;
     line-height: 1rem;
-  }
 
-  .line-all {
-    display: block;
-    .cw,
-    .text {
+    &.line-all {
       display: block;
+      .cw,
+      .text {
+        display: block;
+      }
     }
-  }
-  .line-1,
-  .line-2,
-  .line-3 {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    .cw,
-    .text {
-      display: inline;
-    }
+    &.line-1,
+    &.line-2,
+    &.line-3 {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      .cw,
+      .text {
+        display: inline;
+      }
 
-    .cw + * {
-      margin-left: 8px;
+      .cw + * {
+        margin-left: 8px;
+      }
     }
-  }
-  .line-1 {
-    min-height: 0.8rem;
-    white-space: nowrap;
-    line-clamp: 1;
-  }
-  .line-2 {
-    line-clamp: 2;
-  }
-  .line-3 {
-    line-clamp: 3;
+    &.line-1 {
+      min-height: 0.8rem;
+      white-space: nowrap;
+      -webkit-line-clamp: 1;
+    }
+    &.line-2 {
+      -webkit-line-clamp: 2;
+    }
+    &.line-3 {
+      -webkit-line-clamp: 3;
+    }
   }
 }
 </style>

--- a/src/components/PostItem/MisskeyNoteContent.vue
+++ b/src/components/PostItem/MisskeyNoteContent.vue
@@ -227,52 +227,52 @@ const lineClass = computed(() => {
   color: #efefef;
   font-size: 0.6rem;
   line-height: 1rem;
-}
 
-.read-all {
-  font-size: 0.5rem;
-}
+  .read-all {
+    font-size: 0.5rem;
+  }
 
-.line-all {
-  display: block;
-  .cw,
-  .text {
+  &.line-all {
     display: block;
-  }
+    .cw,
+    .text {
+      display: block;
+    }
 
-  .read-all {
-    margin-top: 4px;
+    .read-all {
+      margin-top: 4px;
+    }
   }
-}
-.line-1,
-.line-2,
-.line-3 {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  .cw,
-  .text {
-    display: inline;
-  }
+  &.line-1,
+  &.line-2,
+  &.line-3 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    .cw,
+    .text {
+      display: inline;
+    }
 
-  .cw + * {
-    margin-left: 8px;
+    .cw + * {
+      margin-left: 8px;
+    }
   }
-}
-.line-1 {
-  min-height: 0.8rem;
-  white-space: nowrap;
-  line-clamp: 1;
-}
-.line-2 {
-  line-clamp: 2;
-  .read-all {
-    margin-top: 4px;
+  &.line-1 {
+    min-height: 0.8rem;
+    white-space: nowrap;
+    -webkit-line-clamp: 1;
   }
-}
-.line-3 {
-  line-clamp: 3;
-  .read-all {
-    margin-top: 4px;
+  &.line-2 {
+    -webkit-line-clamp: 2;
+    .read-all {
+      margin-top: 4px;
+    }
+  }
+  &.line-3 {
+    -webkit-line-clamp: 3;
+    .read-all {
+      margin-top: 4px;
+    }
   }
 }
 </style>

--- a/src/components/PostItem/MisskeyNoteContent.vue
+++ b/src/components/PostItem/MisskeyNoteContent.vue
@@ -62,11 +62,11 @@ const lineClass = computed(() => {
         />
       </div>
     </div>
-    <div class="dote-post-content">
+    <div class="dote-post-content" :class="[props.lineStyle]">
       <Icon icon="mingcute:refresh-3-line" class="post-type-mark" v-if="props.type === 'quoted'" />
       <img
         class="dote-avatar"
-        :class="{ mini: props.type === 'renote', 'line-1': props.lineStyle === 'line-1' }"
+        :class="{ mini: props.type === 'renote' }"
         :src="props.note.user.avatarUrl || ''"
         alt=""
         @click="openUserPage(props.note.user)"
@@ -158,37 +158,27 @@ const lineClass = computed(() => {
 
 .dote-avatar {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
+  width: var(--post-avatar-size);
+  height: var(--post-avatar-size);
   margin: 0 0 auto 0;
   object-fit: cover;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 50%;
-  &.line-1 {
-    width: 20px;
-    height: 20px;
-
-    &.mini {
-      top: 24px;
-      width: 16px;
-      height: 16px;
-    }
-  }
   &.mini {
     position: relative;
-    top: 28px;
+    top: var(--post-avatar-mini-offset);
     z-index: 1;
-    width: 20px;
-    height: 20px;
+    width: var(--post-avatar-mini-size);
+    height: var(--post-avatar-mini-size);
   }
 
   &.origin-user {
     position: absolute;
-    top: 12px;
+    top: var(--post-avatar-origin-offset);
     left: 0;
-    width: 20px;
-    height: 20px;
+    width: var(--post-avatar-origin-size);
+    height: var(--post-avatar-origin-size);
     margin-left: 0;
   }
 
@@ -227,8 +217,8 @@ const lineClass = computed(() => {
   }
 }
 .dote-post-info .renote > .dote-post-body > .dote-avatar {
-  width: 20px;
-  height: 20px;
+  width: var(--post-avatar-mini-size);
+  height: var(--post-avatar-mini-size);
 }
 
 .text-container {

--- a/src/components/PostItem/MisskeyNotification.vue
+++ b/src/components/PostItem/MisskeyNotification.vue
@@ -143,6 +143,7 @@ const openUserPage = (user: MisskeyNote["user"]) => {
         :notification="props.notification"
         :currentInstanceUrl="props.currentInstanceUrl"
         :emojis="props.emojis"
+        :lineStyle="props.lineStyle"
         @openUserPage="openUserPage"
       />
     </div>

--- a/src/components/PostItem/MisskeyNotificationContent.vue
+++ b/src/components/PostItem/MisskeyNotificationContent.vue
@@ -25,6 +25,11 @@ const props = defineProps({
     default: {},
     required: true,
   },
+  lineStyle: {
+    type: String as PropType<"all" | "line-1" | "line-2" | "line-3">,
+    required: false,
+    default: "all",
+  },
 });
 
 const emit = defineEmits(["openUserPage"]);
@@ -68,7 +73,7 @@ const openUserPage = (user: MisskeyNote["user"]) => {
 
 <template>
   <div class="note-content">
-    <div class="dote-post-content">
+    <div class="dote-post-content" :class="[props.lineStyle]">
       <img class="dote-avatar" v-if="user" :src="user.avatarUrl || ''" alt="" @click="openUserPage(user)" />
       <div class="text-container">
         <p v-if="props.notification.type === 'follow'">{{ parseUsername(user?.name) }}があなたをフォローしました</p>
@@ -136,8 +141,8 @@ const openUserPage = (user: MisskeyNote["user"]) => {
 
 .dote-avatar {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
+  width: var(--post-avatar-size);
+  height: var(--post-avatar-size);
   margin: 0 0 auto 0;
   object-fit: cover;
   overflow: hidden;
@@ -145,10 +150,10 @@ const openUserPage = (user: MisskeyNote["user"]) => {
   border-radius: 50%;
   &.mini {
     position: relative;
-    top: 28px;
+    top: var(--post-avatar-mini-offset);
     z-index: 1;
-    width: 20px;
-    height: 20px;
+    width: var(--post-avatar-mini-size);
+    height: var(--post-avatar-mini-size);
   }
 
   & + * {
@@ -187,8 +192,8 @@ const openUserPage = (user: MisskeyNote["user"]) => {
   }
 }
 .dote-post-info .renote > .dote-post-body > .dote-avatar {
-  width: 20px;
-  height: 20px;
+  width: var(--post-avatar-mini-size);
+  height: var(--post-avatar-mini-size);
 }
 
 .text-container {

--- a/src/components/PostItem/MisskeyNotificationContent.vue
+++ b/src/components/PostItem/MisskeyNotificationContent.vue
@@ -230,12 +230,12 @@ const openUserPage = (user: MisskeyNote["user"]) => {
 .line-1 {
   min-height: 0.8rem;
   white-space: nowrap;
-  line-clamp: 1;
+  -webkit-line-clamp: 1;
 }
 .line-2 {
-  line-clamp: 2;
+  -webkit-line-clamp: 2;
 }
 .line-3 {
-  line-clamp: 3;
+  -webkit-line-clamp: 3;
 }
 </style>


### PR DESCRIPTION
## Summary
- add line-style avatar size variables at `.dote-post-content`
- apply lineStyle class and use variables for avatars across post/notification components
- pass lineStyle to MisskeyNotificationContent for consistent sizing

## Testing
- not run (no test/lint/format scripts in package.json)
