### PR TITLE
feat: buffer new posts during readmore

### DIFF
--- a/src/components/Readmore.vue
+++ b/src/components/Readmore.vue
@@ -75,6 +75,7 @@ const readmore = async () => {
     return;
   }
 
+  timelineStore.startReadmore();
   loading.value = true;
 
   switch (timelineStore.currentInstance?.type) {

--- a/src/components/Readmore.vue
+++ b/src/components/Readmore.vue
@@ -75,19 +75,32 @@ const readmore = async () => {
     return;
   }
 
+  const beforeCount = postsOrNotifications.value.length;
   timelineStore.startReadmore();
   loading.value = true;
 
-  switch (timelineStore.currentInstance?.type) {
-    case "bluesky":
-      await blueskyStore.fetchOlderPosts(timelineStore.current.channel);
-      break;
-    default:
-      await fetchOlderPosts(timelineStore.current.channel);
-      break;
+  try {
+    switch (timelineStore.currentInstance?.type) {
+      case "bluesky":
+        await blueskyStore.fetchOlderPosts(timelineStore.current.channel);
+        break;
+      default:
+        await fetchOlderPosts(timelineStore.current.channel);
+        break;
+    }
+  } catch (error) {
+    const message = `${timelineStore.currentInstance?.name ?? "タイムライン"}の過去投稿取得に失敗しました`;
+    store.$state.errors.push({
+      message,
+    });
+    console.error(message, error);
+  } finally {
+    const afterCount = postsOrNotifications.value.length;
+    if (afterCount <= beforeCount) {
+      timelineStore.applyPendingNewPosts();
+    }
+    loading.value = false;
   }
-
-  loading.value = false;
 };
 </script>
 <template>

--- a/src/components/Settings/TimelineSettings.vue
+++ b/src/components/Settings/TimelineSettings.vue
@@ -10,7 +10,7 @@ const store = useStore();
 const timelineStore = useTimelineStore();
 
 const onUpdateTimeline = async (timeline: Timeline) => {
-  await timelineStore.updateTimeline({ ...timeline, posts: [], notifications: [] });
+  await timelineStore.updateTimeline(timeline);
 };
 
 const addTimeline = async () => {

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -329,7 +329,7 @@ onBeforeUnmount(() => {
       <PostList v-if="timelineStore.current?.posts?.length || timelineStore.current?.notifications.length">
         <button v-if="hasPendingNewPosts" class="pending-posts-button nn-button" @click="applyPendingNewPosts">
           ここに読み込む
-          <span class="pending-count" v-if="pendingNewPostsCount">({{ pendingNewPostsCount }}件)</span>
+          <span class="pending-count">({{ pendingNewPostsCount }}件)</span>
         </button>
         <MisskeyNote
           v-if="

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -120,6 +120,8 @@ const hazeOpacity = computed(() => hazeSettings.value.opacity);
 const isHazeMode = computed(() => hazeSettings.value.isEnabled);
 const canScrollToTop = computed(() => scrollState.value.canScrollToTop);
 const canReadMore = computed(() => scrollState.value.canReadMore);
+const pendingNewPostsCount = computed(() => timelineStore.pendingNewPostsCount);
+const hasPendingNewPosts = computed(() => pendingNewPostsCount.value > 0);
 const emojis = computed(() => platformData.value.emojis);
 const ads = computed(() => platformData.value.ads);
 const timelineStyle = computed(() => ({
@@ -266,6 +268,13 @@ const scrollToTop = () => {
   });
 };
 
+/**
+ * Apply queued new posts while readmore is active.
+ */
+const applyPendingNewPosts = () => {
+  timelineStore.applyPendingNewPosts();
+};
+
 timelineStore.$onAction((action) => {
   if (action.name === "addNewPost") {
     nextTick(() => {
@@ -318,6 +327,10 @@ onBeforeUnmount(() => {
       }"
     >
       <PostList v-if="timelineStore.current?.posts?.length || timelineStore.current?.notifications.length">
+        <button v-if="hasPendingNewPosts" class="pending-posts-button nn-button" @click="applyPendingNewPosts">
+          ここに読み込む
+          <span class="pending-count" v-if="pendingNewPostsCount">({{ pendingNewPostsCount }}件)</span>
+        </button>
         <MisskeyNote
           v-if="
             timelineStore.currentInstance?.type === 'misskey' &&
@@ -442,5 +455,17 @@ body::-webkit-scrollbar {
 }
 .dote-post-list {
   padding-top: 4px;
+}
+
+.pending-posts-button {
+  width: calc(100% - 16px);
+  margin: 4px 8px 8px;
+  font-size: var(--font-size-14);
+  justify-content: center;
+}
+
+.pending-count {
+  margin-left: 4px;
+  opacity: 0.7;
 }
 </style>

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -48,7 +48,6 @@ const submitTextMap = {
   reply: "Reply",
   toot: "Toot",
   boost: "Boost",
-  reply: "Reply",
   post: "Post",
   repost: "Repost",
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,6 +34,8 @@ export type TimelineStore = Timeline & {
   bluesky?: {
     cursor?: string;
   };
+  pendingNewPosts: DotEPost[];
+  readmoreLocked: boolean;
 };
 
 export type ErrorItem = {
@@ -247,6 +249,8 @@ export const useStore = defineStore("store", {
             ...timeline,
             posts: [],
             notifications: [],
+            pendingNewPosts: [],
+            readmoreLocked: false,
           };
         });
         console.info("[store] initTimelines:done", this.$state.timelines);

--- a/src/store/mastodon.ts
+++ b/src/store/mastodon.ts
@@ -173,6 +173,11 @@ export const useMastodonStore = defineStore("mastodon", () => {
           (post: DotEPost) => !store.timelines[timeline.currentIndex]?.posts?.some((p: DotEPost) => p.id === post.id),
         );
 
+        if (timeline.isReadmoreLocked) {
+          timeline.queuePendingPosts(filteredPosts);
+          return;
+        }
+
         timeline.setPosts([...filteredPosts, ...store.timelines[timeline.currentIndex]?.posts]);
       } catch (e) {
         store.$state.errors.push({

--- a/src/store/misskey.ts
+++ b/src/store/misskey.ts
@@ -443,6 +443,11 @@ export const useMisskeyStore = defineStore("misskey", () => {
           (post: DotEPost) => !store.timelines[timeline.currentIndex]?.posts?.some((p: DotEPost) => p.id === post.id),
         );
 
+        if (timeline.isReadmoreLocked) {
+          timeline.queuePendingPosts(filteredPosts);
+          return;
+        }
+
         timeline.setPosts([...filteredPosts, ...store.timelines[timeline.currentIndex]?.posts]);
       } catch (e) {
         store.$state.errors.push({

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -66,10 +66,10 @@ export const useTimelineStore = defineStore("timeline", () => {
     const timeline = getCurrentTimeline();
     if (!timeline?.posts) return;
     const existingIds = new Set([
-      ...timeline.posts.map((post) => post.id),
-      ...timeline.pendingNewPosts.map((post) => post.id),
+      ...timeline.posts.map((post: DotEPost) => post.id),
+      ...timeline.pendingNewPosts.map((post: DotEPost) => post.id),
     ]);
-    const unique = posts.filter((post) => !existingIds.has(post.id));
+    const unique = posts.filter((post: DotEPost) => !existingIds.has(post.id));
     if (unique.length === 0) return;
     timeline.pendingNewPosts = [...unique, ...timeline.pendingNewPosts];
   };
@@ -195,7 +195,7 @@ export const useTimelineStore = defineStore("timeline", () => {
     }
   };
 
-  const updateTimeline = async ({ posts, notifications, pendingNewPosts, readmoreLocked, ...timeline }: TimelineStore) => {
+  const updateTimeline = async (timeline: Timeline) => {
     await ipcInvoke("db:set-timeline", timeline);
     await store.initTimelines();
   };
@@ -292,7 +292,7 @@ export const useTimelineStore = defineStore("timeline", () => {
     updatePostAcrossTimelines(store.timelines, post, userId);
     const timeline = getCurrentTimeline();
     if (!timeline?.pendingNewPosts?.length) return;
-    timeline.pendingNewPosts = timeline.pendingNewPosts.map((pending) =>
+    timeline.pendingNewPosts = timeline.pendingNewPosts.map((pending: DotEPost) =>
       pending.id === post.id ? post : pending,
     ) as DotEPost[];
   };

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -18,6 +18,13 @@ export const useTimelineStore = defineStore("timeline", () => {
   const timelines = computed(() => store.$state.timelines);
   let lastReadSaveTimer: ReturnType<typeof setTimeout> | undefined;
 
+  /**
+   * Get the currently active timeline state.
+   */
+  const getCurrentTimeline = () => {
+    return store.$state.timelines[currentIndex.value];
+  };
+
   const currentUser = computed(() => {
     return store.$state.users.find((user) => user.id === current?.value?.userId);
   });
@@ -32,16 +39,77 @@ export const useTimelineStore = defineStore("timeline", () => {
   const misskeyStore = useMisskeyStore();
   const mastodonStore = useMastodonStore();
 
-  const setPosts = (posts: DotEPost[]) => {
-    if (store.$state.timelines[currentIndex.value]) {
-      store.$state.timelines[currentIndex.value].posts = posts;
+  /**
+   * Normalize posts by removing duplicates while keeping order.
+   */
+  const uniquePostsById = (posts: DotEPost[]) => {
+    const seen = new Set<string>();
+    return posts.filter((post) => {
+      if (seen.has(post.id)) return false;
+      seen.add(post.id);
+      return true;
+    });
+  };
 
-      if (store.$state.settings.maxPostCount < store.$state.timelines[currentIndex.value].posts.length) {
-        store.$state.timelines[currentIndex.value].posts = store.$state.timelines[currentIndex.value].posts.slice(
-          0,
-          store.$state.settings.maxPostCount,
-        );
-      }
+  /**
+   * Clear readmore state for the timeline.
+   */
+  const resetReadmoreState = (timeline: TimelineStore) => {
+    timeline.readmoreLocked = false;
+    timeline.pendingNewPosts = [];
+  };
+
+  /**
+   * Queue posts while readmore is active.
+   */
+  const queuePendingPosts = (posts: DotEPost[]) => {
+    const timeline = getCurrentTimeline();
+    if (!timeline?.posts) return;
+    const existingIds = new Set([
+      ...timeline.posts.map((post) => post.id),
+      ...timeline.pendingNewPosts.map((post) => post.id),
+    ]);
+    const unique = posts.filter((post) => !existingIds.has(post.id));
+    if (unique.length === 0) return;
+    timeline.pendingNewPosts = [...unique, ...timeline.pendingNewPosts];
+  };
+
+  /**
+   * Apply pending posts to the timeline and unlock readmore.
+   */
+  const applyPendingNewPosts = () => {
+    const timeline = getCurrentTimeline();
+    if (!timeline?.posts) return;
+    if (!timeline.pendingNewPosts.length) {
+      timeline.readmoreLocked = false;
+      return;
+    }
+    const mergedPosts = uniquePostsById([...timeline.pendingNewPosts, ...timeline.posts]);
+    timeline.posts = mergedPosts.slice(0, store.$state.settings.maxPostCount);
+    timeline.pendingNewPosts = [];
+    timeline.readmoreLocked = false;
+  };
+
+  /**
+   * Lock timeline updates while readmore is active.
+   */
+  const startReadmore = () => {
+    const timeline = getCurrentTimeline();
+    if (!timeline) return;
+    timeline.readmoreLocked = true;
+  };
+
+  const pendingNewPostsCount = computed(() => getCurrentTimeline()?.pendingNewPosts?.length ?? 0);
+  const isReadmoreLocked = computed(() => getCurrentTimeline()?.readmoreLocked ?? false);
+
+  const setPosts = (posts: DotEPost[]) => {
+    const timeline = getCurrentTimeline();
+    if (!timeline) return;
+    timeline.posts = posts;
+    resetReadmoreState(timeline);
+
+    if (store.$state.settings.maxPostCount < timeline.posts.length) {
+      timeline.posts = timeline.posts.slice(0, store.$state.settings.maxPostCount);
     }
   };
 
@@ -68,7 +136,7 @@ export const useTimelineStore = defineStore("timeline", () => {
       clearTimeout(lastReadSaveTimer);
     }
     lastReadSaveTimer = setTimeout(async () => {
-      const { posts, notifications, bluesky, ...timelineForStore } = timeline;
+      const { posts, notifications, bluesky, pendingNewPosts, readmoreLocked, ...timelineForStore } = timeline;
       try {
         await ipcInvoke("db:set-timeline", timelineForStore);
       } catch (error) {
@@ -124,7 +192,7 @@ export const useTimelineStore = defineStore("timeline", () => {
     }
   };
 
-  const updateTimeline = async ({ posts, ...timeline }: TimelineStore) => {
+  const updateTimeline = async ({ posts, notifications, pendingNewPosts, readmoreLocked, ...timeline }: TimelineStore) => {
     await ipcInvoke("db:set-timeline", timeline);
     await store.initTimelines();
   };
@@ -189,7 +257,7 @@ export const useTimelineStore = defineStore("timeline", () => {
     }
     if (store.timelines[index].available) return;
     store.timelines.forEach(async (timeline, i) => {
-      const { posts, notifications, ...timelineForStore } = timeline;
+      const { posts, notifications, pendingNewPosts, readmoreLocked, ...timelineForStore } = timeline;
 
       await ipcInvoke("db:set-timeline", {
         ...timelineForStore,
@@ -200,14 +268,18 @@ export const useTimelineStore = defineStore("timeline", () => {
   };
 
   const addNewPost = (post: DotEPost) => {
-    // abort if no posts
-    if (!store.timelines[currentIndex.value]?.posts) return;
+    const timeline = getCurrentTimeline();
+    if (!timeline?.posts) return;
+    if (timeline.readmoreLocked) {
+      queuePendingPosts([post]);
+      return;
+    }
     // detect duplicate
-    if (store.timelines[currentIndex.value].posts.some((p: DotEPost) => p.id === post.id)) return;
-    store.timelines[currentIndex.value].posts = [post, ...store.timelines[currentIndex.value].posts] as DotEPost[];
+    if (timeline.posts.some((p: DotEPost) => p.id === post.id)) return;
+    timeline.posts = [post, ...timeline.posts] as DotEPost[];
 
-    if (store.settings.maxPostCount < store.timelines[currentIndex.value].posts.length) {
-      store.timelines[currentIndex.value].posts.pop();
+    if (store.settings.maxPostCount < timeline.posts.length) {
+      timeline.posts.pop();
     }
   };
 
@@ -215,13 +287,20 @@ export const useTimelineStore = defineStore("timeline", () => {
     const userId = currentUser.value?.id;
     if (!userId) return;
     updatePostAcrossTimelines(store.timelines, post, userId);
+    const timeline = getCurrentTimeline();
+    if (!timeline?.pendingNewPosts?.length) return;
+    timeline.pendingNewPosts = timeline.pendingNewPosts.map((pending) =>
+      pending.id === post.id ? post : pending,
+    ) as DotEPost[];
   };
 
   const removePost = (postId: string) => {
-    if (!store.timelines[currentIndex.value]?.posts) return;
-    store.timelines[currentIndex.value].posts = store.timelines[currentIndex.value].posts.filter(
-      (post: DotEPost) => post.id !== postId,
-    ) as DotEPost[];
+    const timeline = getCurrentTimeline();
+    if (!timeline?.posts) return;
+    timeline.posts = timeline.posts.filter((post: DotEPost) => post.id !== postId) as DotEPost[];
+    if (timeline.pendingNewPosts.length) {
+      timeline.pendingNewPosts = timeline.pendingNewPosts.filter((post: DotEPost) => post.id !== postId) as DotEPost[];
+    }
   };
 
   const addNewNotification = <T extends MisskeyEntities.Notification | MastodonNotification>(notification: T) => {
@@ -233,14 +312,11 @@ export const useTimelineStore = defineStore("timeline", () => {
   };
 
   const addMorePosts = (posts: DotEPost[]) => {
-    if (!store.timelines[currentIndex.value]?.posts) return;
-    const filteredPosts = posts.filter(
-      (post: DotEPost) => !store.timelines[currentIndex.value].posts.some((p: DotEPost) => p.id === post.id),
-    );
-    store.timelines[currentIndex.value].posts = [
-      ...store.timelines[currentIndex.value].posts,
-      ...filteredPosts,
-    ] as DotEPost[];
+    const timeline = getCurrentTimeline();
+    if (!timeline?.posts) return;
+    timeline.readmoreLocked = true;
+    const filteredPosts = posts.filter((post: DotEPost) => !timeline.posts.some((p: DotEPost) => p.id === post.id));
+    timeline.posts = [...timeline.posts, ...filteredPosts] as DotEPost[];
   };
 
   const addMoreNotifications = (notifications: MisskeyEntities.Notification[] | MastodonNotification[]) => {
@@ -281,5 +357,10 @@ export const useTimelineStore = defineStore("timeline", () => {
     setPosts,
     setNotifications,
     setLastReadId,
+    startReadmore,
+    queuePendingPosts,
+    applyPendingNewPosts,
+    pendingNewPostsCount,
+    isReadmoreLocked,
   };
 });

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -364,5 +364,6 @@ export const useTimelineStore = defineStore("timeline", () => {
     applyPendingNewPosts,
     pendingNewPostsCount,
     isReadmoreLocked,
+    setLastReadId,
   };
 });

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -85,6 +85,7 @@ export const useTimelineStore = defineStore("timeline", () => {
       return;
     }
     const mergedPosts = uniquePostsById([...timeline.pendingNewPosts, ...timeline.posts]);
+    // Keep only the newest posts within maxPostCount.
     timeline.posts = mergedPosts.slice(0, store.$state.settings.maxPostCount);
     timeline.pendingNewPosts = [];
     timeline.readmoreLocked = false;
@@ -106,7 +107,9 @@ export const useTimelineStore = defineStore("timeline", () => {
     const timeline = getCurrentTimeline();
     if (!timeline) return;
     timeline.posts = posts;
-    resetReadmoreState(timeline);
+    if (!timeline.readmoreLocked) {
+      resetReadmoreState(timeline);
+    }
 
     if (store.$state.settings.maxPostCount < timeline.posts.length) {
       timeline.posts = timeline.posts.slice(0, store.$state.settings.maxPostCount);
@@ -314,7 +317,6 @@ export const useTimelineStore = defineStore("timeline", () => {
   const addMorePosts = (posts: DotEPost[]) => {
     const timeline = getCurrentTimeline();
     if (!timeline?.posts) return;
-    timeline.readmoreLocked = true;
     const filteredPosts = posts.filter((post: DotEPost) => !timeline.posts.some((p: DotEPost) => p.id === post.id));
     timeline.posts = [...timeline.posts, ...filteredPosts] as DotEPost[];
   };

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -364,6 +364,5 @@ export const useTimelineStore = defineStore("timeline", () => {
     applyPendingNewPosts,
     pendingNewPostsCount,
     isReadmoreLocked,
-    setLastReadId,
   };
 });


### PR DESCRIPTION
## Summary
- add readmore lock + pending post queue per timeline
- queue new/diff posts while readmore is active and expose apply action
- add "ここに読み込む" button with pending count in timeline view

## Testing
- not run (no test/lint/format scripts in package.json)
