### PR TITLE
feat: track timeline read state

### DIFF
--- a/main/db.ts
+++ b/main/db.ts
@@ -94,6 +94,7 @@ const schema: Schema<StoreSchema> = {
         updateInterval: { type: "number" },
         available: { type: "boolean" },
         lastReadId: { type: "string" },
+        lastReadAt: { type: "string" },
       },
       required: ["id", "userId", "channel", "available"],
     },

--- a/main/db.ts
+++ b/main/db.ts
@@ -93,6 +93,7 @@ const schema: Schema<StoreSchema> = {
         },
         updateInterval: { type: "number" },
         available: { type: "boolean" },
+        lastReadId: { type: "string" },
       },
       required: ["id", "userId", "channel", "available"],
     },

--- a/shared/types/store.d.ts
+++ b/shared/types/store.d.ts
@@ -39,6 +39,7 @@ export type Timeline = {
   };
   updateInterval: number;
   available: boolean;
+  lastReadId?: string;
 };
 
 type InsranceBase = {

--- a/shared/types/store.d.ts
+++ b/shared/types/store.d.ts
@@ -40,6 +40,7 @@ export type Timeline = {
   updateInterval: number;
   available: boolean;
   lastReadId?: string;
+  lastReadAt?: string;
 };
 
 type InsranceBase = {

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -27,6 +27,14 @@ input {
   visibility: hidden;
 }
 
+.dote-post {
+  transition: opacity 0.2s ease;
+
+  &.is-read {
+    opacity: 0.6;
+  }
+}
+
 .dote-field-group-title {
   display: block;
   padding: 8px 16px 0px;

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -27,7 +27,7 @@ input {
   visibility: hidden;
 }
 
-.dote-post {
+.post-item {
   transition: opacity 0.2s ease;
 
   &.is-read {


### PR DESCRIPTION
## Summary
- add lastReadId to timeline schema and store
- observe visible posts to persist last read id (debounced)
- mark read posts with a dimmed style via `is-read`

## Testing
- not run (no test/lint/format scripts in package.json)
