### PR TITLE
feat: add mastodon reply flow

### DIFF
--- a/src/components/PostItem/MastodonToot.vue
+++ b/src/components/PostItem/MastodonToot.vue
@@ -34,7 +34,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["refreshPost", "reaction", "favourite"]);
+const emit = defineEmits(["refreshPost", "reaction", "favourite", "reply"]);
 
 const post = computed(() => {
   return props.post.reblog || props.post;
@@ -79,6 +79,13 @@ const openPost = () => {
 
 const openUserPage = (user: MastodonToot["account"]) => {
   ipcSend("open-url", { url: user.url });
+};
+
+/**
+ * Emit reply action for this toot.
+ */
+const replyToPost = () => {
+  emit("reply", post.value);
 };
 </script>
 
@@ -128,6 +135,9 @@ const openUserPage = (user: MastodonToot["account"]) => {
       </button>
     </div>
     <div class="dote-post-actions">
+      <button class="dote-post-action" @click="replyToPost" v-if="props.showActions">
+        <Icon class="nn-icon size-xsmall" icon="mingcute:message-2-line" />
+      </button>
       <button class="dote-post-action" @click="refreshPost" v-if="props.showActions">
         <Icon class="nn-icon size-xsmall" icon="mingcute:refresh-1-line" />
       </button>

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -92,6 +92,13 @@ const onMisskeyRepost = (payload: { post: MisskeyNoteType; emojis: { name: strin
   ipcSend("post:repost", payload);
 };
 
+/**
+ * Mastodonの返信ウィンドウを開きます。
+ */
+const onMastodonReply = (toot: MastodonTootType) => {
+  ipcSend("post:create", { post: toot, mode: "reply", replyToId: toot.id });
+};
+
 const timelineContainer = ref<HTMLDivElement | null>(null);
 
 // Computed values from composables
@@ -201,6 +208,7 @@ onMounted(() => {
           :lineStyle="store.settings.postStyle"
           @refreshPost="mastodonStore.updatePost"
           @favourite="mastodonStore.toggleFavourite"
+          @reply="onMastodonReply"
         />
         <MastodonNotification
           v-if="timelineStore.current.channel === 'mastodon:notifications'"

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -2,6 +2,7 @@
 import DoteAlert from "@/components/common/DoteAlert.vue";
 import DoteButton from "@/components/common/DoteButton.vue";
 import BlueskyPost from "@/components/PostItem/BlueskyPost.vue";
+import MastodonToot from "@/components/PostItem/MastodonToot.vue";
 import MisskeyNote from "@/components/PostItem/MisskeyNote.vue";
 import EmojiPicker from "@/components/EmojiPicker.vue";
 import Mfm from "@/components/misskey/Mfm.vue";
@@ -19,6 +20,8 @@ import type { ApiInvokeResult } from "@shared/types/ipc";
 type PageProps = {
   post?: MisskeyNoteType | MastodonTootType | BlueskyPostType;
   emojis?: MisskeyEntities.EmojiSimple[];
+  mode?: "reply";
+  replyToId?: string;
 };
 
 type UploadStatus = "ready" | "uploading" | "uploaded" | "failed";
@@ -44,6 +47,7 @@ const submitTextMap = {
   quote: "Quote",
   toot: "Toot",
   boost: "Boost",
+  reply: "Reply",
   post: "Post",
   repost: "Repost",
 };
@@ -103,6 +107,18 @@ const uploadedMastodonMediaIds = computed(() =>
   attachments.value.filter((item) => item.status === "uploaded" && item.mediaId).map((item) => item.mediaId as string),
 );
 const hasAttachments = computed(() => attachments.value.length > 0);
+const isReplyMode = computed(() => props.data.mode === "reply");
+
+const mastodonReplyTarget = computed(() => {
+  if (!isReplyMode.value) return null;
+  if (state.instance?.type !== "mastodon") return null;
+  return props.data.post as MastodonTootType | null;
+});
+
+const replyToId = computed(() => {
+  if (!isReplyMode.value) return undefined;
+  return props.data.replyToId ?? (mastodonReplyTarget.value?.id || undefined);
+});
 
 const handleApiResult = <T>(result: ApiInvokeResult<T>, message: string): T | undefined => {
   if (!result.ok) {
@@ -188,6 +204,9 @@ const submitType = computed(() => {
     return "note";
   }
   if (state.instance?.type === "mastodon") {
+    if (isReplyMode.value) {
+      return "reply";
+    }
     if (mastodonToot.value) {
       return "boost";
     }
@@ -450,7 +469,7 @@ const postToMastodon = async () => {
     instanceUrl: state.instance?.url,
     token: state.user?.token,
     status: text.value,
-    // inReplyToId: null,
+    ...(replyToId.value ? { inReplyToId: replyToId.value } : {}),
     mediaIds,
     // sensitive: false,
     // spoilerText: null,
@@ -698,6 +717,15 @@ document.addEventListener("keydown", (e) => {
       </div>
     </div>
     <div class="post-container">
+      <MastodonToot
+        v-if="mastodonReplyTarget"
+        class="post-item"
+        :post="mastodonReplyTarget"
+        :instanceUrl="state.instance?.url"
+        :showReactions="false"
+        :showActions="false"
+        lineStyle="all"
+      />
       <MisskeyNote
         v-if="misskeyNote"
         class="post-item"

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -229,7 +229,12 @@ const canSubmit = computed(() => {
     return false;
   }
 
-  if (submitType.value === "note" || submitType.value === "toot" || submitType.value === "post") {
+  if (
+    submitType.value === "note" ||
+    submitType.value === "toot" ||
+    submitType.value === "reply" ||
+    submitType.value === "post"
+  ) {
     if (state.instance?.type === "misskey") {
       return text.value.length > 0 || hasAttachments.value;
     }


### PR DESCRIPTION
## Summary
- add reply action to Mastodon toot cards
- open post composer in reply mode from timeline
- support reply mode + preview + inReplyToId in post/create

## Testing
- not run (no test/lint/format scripts in package.json)
