### PR TITLE
feat: add mastodon boost flow

### DIFF
--- a/main/api/index.ts
+++ b/main/api/index.ts
@@ -43,6 +43,8 @@ export const apiRequest = {
   ["mastodon:getStaus"]: mastodonRequest.mastodonGetStatus,
   ["mastodon:favourite"]: mastodonRequest.mastodonFavourite,
   ["mastodon:unFavourite"]: mastodonRequest.mastodonUnFavourite,
+  ["mastodon:reblog"]: mastodonRequest.mastodonReblog,
+  ["mastodon:unReblog"]: mastodonRequest.mastodonUnReblog,
   ["mastodon:getList"]: mastodonRequest.mastodonGetList,
 
   ["bluesky:startOAuth"]: blueskyStartOAuth,

--- a/main/api/mastodon.ts
+++ b/main/api/mastodon.ts
@@ -366,6 +366,44 @@ export const mastodonUnFavourite = async ({
   });
 };
 
+export const mastodonReblog = async ({
+  instanceUrl,
+  token,
+  id,
+}: {
+  instanceUrl: string;
+  token: string;
+  id: string;
+}) => {
+  const url = new URL(`/api/v1/statuses/${id}/reblog`, instanceUrl).toString();
+  return requestJson(url, {
+    method: "POST",
+    headers: {
+      ...baseHeader,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+};
+
+export const mastodonUnReblog = async ({
+  instanceUrl,
+  token,
+  id,
+}: {
+  instanceUrl: string;
+  token: string;
+  id: string;
+}) => {
+  const url = new URL(`/api/v1/statuses/${id}/unreblog`, instanceUrl).toString();
+  return requestJson(url, {
+    method: "POST",
+    headers: {
+      ...baseHeader,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+};
+
 export const mastodonGetStatus = async ({
   instanceUrl,
   token,

--- a/src/components/PostItem/MastodonToot.vue
+++ b/src/components/PostItem/MastodonToot.vue
@@ -34,7 +34,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["refreshPost", "reaction", "favourite"]);
+const emit = defineEmits(["refreshPost", "reaction", "favourite", "boost"]);
 
 const post = computed(() => {
   return props.post.reblog || props.post;
@@ -79,6 +79,13 @@ const openPost = () => {
 
 const openUserPage = (user: MastodonToot["account"]) => {
   ipcSend("open-url", { url: user.url });
+};
+
+/**
+ * Emit boost action for this toot.
+ */
+const boostPost = () => {
+  emit("boost", post.value);
 };
 </script>
 
@@ -128,6 +135,9 @@ const openUserPage = (user: MastodonToot["account"]) => {
       </button>
     </div>
     <div class="dote-post-actions">
+      <button class="dote-post-action" @click="boostPost" v-if="props.showActions">
+        <Icon class="nn-icon size-xsmall" icon="mingcute:repeat-fill" />
+      </button>
       <button class="dote-post-action" @click="refreshPost" v-if="props.showActions">
         <Icon class="nn-icon size-xsmall" icon="mingcute:refresh-1-line" />
       </button>

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -92,6 +92,13 @@ const onMisskeyRepost = (payload: { post: MisskeyNoteType; emojis: { name: strin
   ipcSend("post:repost", payload);
 };
 
+/**
+ * MastodonのBoost確認画面を開きます。
+ */
+const onMastodonBoost = (toot: MastodonTootType) => {
+  ipcSend("post:repost", { post: toot, mode: "boost" });
+};
+
 const timelineContainer = ref<HTMLDivElement | null>(null);
 
 // Computed values from composables
@@ -201,6 +208,7 @@ onMounted(() => {
           :lineStyle="store.settings.postStyle"
           @refreshPost="mastodonStore.updatePost"
           @favourite="mastodonStore.toggleFavourite"
+          @boost="onMastodonBoost"
         />
         <MastodonNotification
           v-if="timelineStore.current.channel === 'mastodon:notifications'"

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -123,15 +123,27 @@ const handleApiResult = <T>(result: ApiInvokeResult<T>, message: string): T | un
 
 const mastodonToot = computed(() => {
   if (state.instance?.type === "mastodon" && props.data.post) {
+    const target = props.data.post as MastodonTootType;
+    const original = target.reblog ?? target;
+    const boosterAccount = {
+      ...original.account,
+      display_name: state.user?.name ?? original.account.display_name,
+      avatar: state.user?.avatarUrl ?? original.account.avatar,
+      url: original.account.url,
+    } as MastodonTootType["account"];
+
     return {
-      account: {
-        name: state.user?.name,
-        host: state.instance?.url,
-        avatarUrl: state.user?.avatarUrl,
-      },
-      reblog: props.data.post as MastodonTootType["reblog"],
-    } as unknown as MastodonTootType;
+      ...original,
+      id: target.id ?? original.id,
+      account: boosterAccount,
+      reblog: original,
+      media_attachments: original.media_attachments ?? [],
+      sensitive: Boolean(original.sensitive),
+      favourited: Boolean(original.favourited),
+      favourites_count: original.favourites_count ?? 0,
+    } as MastodonTootType;
   }
+  return null;
 });
 
 const misskeyNote = computed(() => {
@@ -197,9 +209,6 @@ const submitType = computed(() => {
   }
   if (state.instance?.type === "mastodon") {
     if (isBoostMode.value) {
-      return "boost";
-    }
-    if (mastodonToot.value) {
       return "boost";
     }
     return "toot";

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -2,6 +2,7 @@
 import DoteAlert from "@/components/common/DoteAlert.vue";
 import DoteButton from "@/components/common/DoteButton.vue";
 import BlueskyPost from "@/components/PostItem/BlueskyPost.vue";
+import MastodonToot from "@/components/PostItem/MastodonToot.vue";
 import MisskeyNote from "@/components/PostItem/MisskeyNote.vue";
 import EmojiPicker from "@/components/EmojiPicker.vue";
 import Mfm from "@/components/misskey/Mfm.vue";
@@ -19,6 +20,7 @@ import type { ApiInvokeResult } from "@shared/types/ipc";
 type PageProps = {
   post?: MisskeyNoteType | MastodonTootType | BlueskyPostType;
   emojis?: MisskeyEntities.EmojiSimple[];
+  mode?: "boost";
 };
 
 type UploadStatus = "ready" | "uploading" | "uploaded" | "failed";
@@ -103,6 +105,12 @@ const uploadedMastodonMediaIds = computed(() =>
   attachments.value.filter((item) => item.status === "uploaded" && item.mediaId).map((item) => item.mediaId as string),
 );
 const hasAttachments = computed(() => attachments.value.length > 0);
+const isBoostMode = computed(() => props.data.mode === "boost");
+const boostTargetId = computed(() => {
+  if (!isBoostMode.value) return undefined;
+  const target = props.data.post as MastodonTootType | undefined;
+  return target?.id;
+});
 
 const handleApiResult = <T>(result: ApiInvokeResult<T>, message: string): T | undefined => {
   if (!result.ok) {
@@ -188,6 +196,9 @@ const submitType = computed(() => {
     return "note";
   }
   if (state.instance?.type === "mastodon") {
+    if (isBoostMode.value) {
+      return "boost";
+    }
     if (mastodonToot.value) {
       return "boost";
     }
@@ -441,6 +452,24 @@ const postToMisskey = async () => {
 };
 
 const postToMastodon = async () => {
+  if (isBoostMode.value) {
+    if (!boostTargetId.value) {
+      state.post.error = "ブースト対象の投稿が見つかりませんでした";
+      return;
+    }
+    const result = await ipcInvoke("api", {
+      method: "mastodon:reblog",
+      instanceUrl: state.instance?.url,
+      token: state.user?.token,
+      id: boostTargetId.value,
+    });
+    const res = handleApiResult(result, `${state.instance?.name ?? "Mastodon"} のブーストに失敗しました`);
+    if (res) {
+      ipcSend("post:close");
+    }
+    return;
+  }
+
   if (!(await uploadMastodonAttachments())) {
     return;
   }
@@ -587,8 +616,15 @@ document.addEventListener("keydown", (e) => {
     </div>
     <div class="post-layout">
       <div class="post-field-container">
-        <ElInput class="post-field" :autosize="{ minRows: 2 }" type="textarea" v-model="text" ref="textInputRef" />
-        <div class="post-tools" v-if="canUseEmojiPicker || canUseMfmPreview">
+        <ElInput
+          class="post-field"
+          :autosize="{ minRows: 2 }"
+          type="textarea"
+          v-model="text"
+          ref="textInputRef"
+          :disabled="isBoostMode"
+        />
+        <div class="post-tools" v-if="!isBoostMode && (canUseEmojiPicker || canUseMfmPreview)">
           <button v-if="canUseEmojiPicker" class="nn-button size-small tool-button" @click="toggleEmojiPicker">
             <Icon icon="mingcute:emoji-line" class="nn-icon size-xsmall" />
             <span>絵文字</span>
@@ -603,7 +639,7 @@ document.addEventListener("keydown", (e) => {
             <span>プレビュー</span>
           </button>
         </div>
-        <div class="post-tools" v-if="canUseMisskeyOptions">
+        <div class="post-tools" v-if="!isBoostMode && canUseMisskeyOptions">
           <button
             class="nn-button size-small tool-button"
             :class="{ active: showMisskeyOptions }"
@@ -613,24 +649,24 @@ document.addEventListener("keydown", (e) => {
             <span>投稿設定</span>
           </button>
         </div>
-        <div class="post-tools" v-if="canUseAttachments">
+        <div class="post-tools" v-if="!isBoostMode && canUseAttachments">
           <button class="nn-button size-small tool-button" @click="openFilePicker">
             <Icon icon="mingcute:attachment-line" class="nn-icon size-xsmall" />
             <span>添付</span>
           </button>
           <input class="file-input" type="file" multiple ref="fileInputRef" @change="onSelectFiles" />
         </div>
-        <div class="emoji-picker-panel" v-if="canUseEmojiPicker && showEmojiPicker">
+        <div class="emoji-picker-panel" v-if="!isBoostMode && canUseEmojiPicker && showEmojiPicker">
           <EmojiPicker ref="emojiPickerRef" :emojis="props.data.emojis || []" @select="onSelectEmoji" />
         </div>
-        <div class="mfm-preview-panel" v-if="canUseMfmPreview && showMfmPreview">
+        <div class="mfm-preview-panel" v-if="!isBoostMode && canUseMfmPreview && showMfmPreview">
           <div class="mfm-preview-header">MFM プレビュー</div>
           <div class="mfm-preview-body">
             <Mfm :text="text" :emojis="props.data.emojis || []" :host="state.instance?.url" postStyle="all" />
             <div class="mfm-preview-empty" v-if="text.length === 0">本文を入力するとプレビューが表示されます</div>
           </div>
         </div>
-        <div class="misskey-options" v-if="canUseMisskeyOptions && showMisskeyOptions">
+        <div class="misskey-options" v-if="!isBoostMode && canUseMisskeyOptions && showMisskeyOptions">
           <div class="misskey-options-row">
             <label class="nn-label">公開範囲</label>
             <select class="nn-select" v-model="misskeyVisibility">
@@ -667,7 +703,7 @@ document.addEventListener("keydown", (e) => {
             </label>
           </div>
         </div>
-        <div class="attachments-panel" v-if="attachments.length">
+        <div class="attachments-panel" v-if="!isBoostMode && attachments.length">
           <div class="attachment-item" v-for="item in attachments" :key="item.id" :class="[item.status]">
             <div class="attachment-preview" v-if="item.previewUrl">
               <img :src="item.previewUrl" :alt="item.name" />
@@ -698,6 +734,15 @@ document.addEventListener("keydown", (e) => {
       </div>
     </div>
     <div class="post-container">
+      <MastodonToot
+        v-if="isBoostMode && mastodonToot"
+        class="post-item"
+        :post="mastodonToot"
+        :instanceUrl="state.instance?.url"
+        :showReactions="false"
+        :showActions="false"
+        lineStyle="all"
+      />
       <MisskeyNote
         v-if="misskeyNote"
         class="post-item"


### PR DESCRIPTION
## Summary
- add reblog/unreblog endpoints to mastodon api and store
- add boost action on toot cards to open confirmation
- support boost mode in post/create with disabled input + preview

## Testing
- not run (no test/lint/format scripts in package.json)
