### PR TITLE
feat: add misskey reply flow

### DIFF
--- a/src/components/PostItem/MisskeyNote.vue
+++ b/src/components/PostItem/MisskeyNote.vue
@@ -23,6 +23,7 @@ const emit = defineEmits<{
   reaction: [data: { postId: string; reaction: string }];
   newReaction: [postId: string];
   repost: [data: { post: MisskeyNote; emojis: { name: string; url: string }[] }];
+  reply: [post: MisskeyNote];
 }>();
 
 // Composables
@@ -68,6 +69,13 @@ const openRepostWindow = () => {
 
 const onClickReaction = (postId: string, reaction: string) => {
   onClickReactionAction(postId, reaction, emit);
+};
+
+/**
+ * Emit reply action for this note.
+ */
+const replyToPost = () => {
+  emit("reply", props.post);
 };
 
 // Setup stream subscription
@@ -121,6 +129,9 @@ setupStreamSubscription();
     <div class="dote-post-actions">
       <button class="dote-post-action" @click="refreshPost" v-if="props.showActions">
         <Icon class="nn-icon size-xsmall" icon="mingcute:refresh-1-fill" />
+      </button>
+      <button class="dote-post-action" @click="replyToPost" v-if="props.showActions">
+        <Icon class="nn-icon size-xsmall" icon="mingcute:message-2-line" />
       </button>
       <button class="dote-post-action" @click="openReactionWindow" v-if="props.showActions">
         <Icon class="nn-icon size-xsmall" icon="mingcute:add-fill" />

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -92,6 +92,13 @@ const onMisskeyRepost = (payload: { post: MisskeyNoteType; emojis: { name: strin
   ipcSend("post:repost", payload);
 };
 
+/**
+ * Misskeyの返信ウィンドウを開きます。
+ */
+const onMisskeyReply = (note: MisskeyNoteType) => {
+  ipcSend("post:create", { post: note, emojis: emojis.value, mode: "reply", replyToId: note.id });
+};
+
 const timelineContainer = ref<HTMLDivElement | null>(null);
 
 // Computed values from composables
@@ -176,6 +183,7 @@ onMounted(() => {
           @newReaction="onMisskeyNewReaction"
           @refreshPost="onMisskeyRefreshPost"
           @repost="onMisskeyRepost"
+          @reply="onMisskeyReply"
         />
         <MisskeyNotification
           v-if="timelineStore.current.channel === 'misskey:notifications'"

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -228,7 +228,12 @@ const canSubmit = computed(() => {
     return false;
   }
 
-  if (submitType.value === "note" || submitType.value === "toot" || submitType.value === "post") {
+  if (
+    submitType.value === "note" ||
+    submitType.value === "reply" ||
+    submitType.value === "toot" ||
+    submitType.value === "post"
+  ) {
     if (state.instance?.type === "misskey") {
       return text.value.length > 0 || hasAttachments.value;
     }


### PR DESCRIPTION
## Summary
- add reply action on misskey note cards
- open post/create in reply mode from timeline
- pass replyId to misskey:createNote and show reply preview

## Testing
- not run (no test/lint/format scripts in package.json)
