### PR TITLE
fix: keep settings open after Mastodon account add

### DIFF
--- a/src/components/Settings/AccountSettings.vue
+++ b/src/components/Settings/AccountSettings.vue
@@ -55,9 +55,9 @@ const exitAddAccount = () => {
   newAccountInstanceType.value = undefined;
 };
 
-const createAccount = (user: NewUser) => {
+const createAccount = async (user: NewUser) => {
   newAccountInstanceType.value = undefined;
-  usersStore.createUser(user);
+  await usersStore.createUser(user);
 };
 
 const closeAddAccount = () => {

--- a/src/components/Settings/AddAccountMastodon.vue
+++ b/src/components/Settings/AddAccountMastodon.vue
@@ -16,7 +16,7 @@ const authCode = ref("");
 const accessToken = ref("");
 const store = useStore();
 
-const unwrapApiResult = <T>(result: ApiInvokeResult<T>, message: string): T | undefined => {
+const unwrapApiResult = <T,>(result: ApiInvokeResult<T>, message: string): T | undefined => {
   if (!result.ok) {
     store.$state.errors.push({
       message,
@@ -74,11 +74,6 @@ const checkMastodonAuth = async () => {
   if (!res) return;
   accessToken.value = (res as any).access_token;
   await fetchAndSetMastodonMyself(accessToken.value);
-
-  // 色々リセットするのが面倒なのでリロード
-  setTimeout(() => {
-    window.ipc.send("main:reload");
-  }, 100);
 };
 
 const fetchAndSetMastodonMyself = async (token: string) => {


### PR DESCRIPTION
Closes #303

## Summary
- remove the forced main window reload after Mastodon account authorization
- await account creation in settings so the updated list/timeline state is applied before continuing
- keep the user on the settings screen until they explicitly navigate back

## Verification
- timeout 180 pnpm typecheck