### PR TITLE
fix: reconnect unhealthy Misskey streams

### DIFF
--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -3,7 +3,7 @@ import { useTimelineStore } from "@/store/timeline";
 import { mastodonChannels } from "@/utils/mastodon";
 import { misskeyChannels } from "@/utils/misskey";
 import { useBlueskyPolling, useMisskeyPolling } from "@/utils/polling";
-import { MisskeyStreamChannel, useMisskeyStream } from "@/utils/misskeyStream";
+import { MisskeyStreamChannel, useMisskeyStream, webSocketState as misskeyWebSocketState } from "@/utils/misskeyStream";
 import { BlueskyChannelName, MastodonChannelName, MisskeyChannelName } from "@shared/types/store";
 import { blueskyChannels } from "@/utils/bluesky";
 import { nextTick } from "vue";
@@ -17,6 +17,7 @@ export function useStream() {
   const store = useStore();
   const timelineStore = useTimelineStore();
   const misskeyStore = useMisskeyStore();
+  let misskeyHealthCheckTimer: number | undefined;
 
   const misskeyStream = useMisskeyStream({
     onChannel: (event, data) => {
@@ -116,6 +117,39 @@ export function useStream() {
 
       await misskeyStore.createMyReaction(targetPost.id, data.reaction);
     });
+
+    window.ipc?.on("resume-timeline", () => {
+      const currentTimeline = timelineStore.current;
+      if (timelineStore.currentInstance?.type !== "misskey") return;
+      if (!currentTimeline) return;
+      if (!misskeyChannels.includes(currentTimeline.channel as MisskeyChannelName)) return;
+      if (currentTimeline.channel === "misskey:search") return;
+      misskeyStream.reconnect(true);
+    });
+  };
+
+  const stopMisskeyHealthCheck = () => {
+    if (!misskeyHealthCheckTimer) return;
+    window.clearInterval(misskeyHealthCheckTimer);
+    misskeyHealthCheckTimer = undefined;
+  };
+
+  const startMisskeyHealthCheck = () => {
+    stopMisskeyHealthCheck();
+    misskeyHealthCheckTimer = window.setInterval(() => {
+      const currentTimeline = timelineStore.current;
+      if (timelineStore.currentInstance?.type !== "misskey") return;
+      if (!currentTimeline) return;
+      if (!misskeyChannels.includes(currentTimeline.channel as MisskeyChannelName)) return;
+      if (currentTimeline.channel === "misskey:search") return;
+
+      const state = misskeyStream.state.value;
+      if (state === misskeyWebSocketState.OPEN || state === misskeyWebSocketState.CONNECTING) {
+        return;
+      }
+
+      misskeyStream.reconnect();
+    }, 30 * 1000);
   };
 
   // ストリーム初期化関数
@@ -128,6 +162,7 @@ export function useStream() {
     misskeyPolling.stopPolling();
     mastodonStream.disconnect();
     blueskyPolling.stopPolling();
+    stopMisskeyHealthCheck();
 
     if (mastodonChannels.includes(current.channel as MastodonChannelName)) {
       if (current.channel === "mastodon:list" && !current.options?.listId) {
@@ -191,6 +226,7 @@ export function useStream() {
           antennaId: current.options?.antennaId,
           listId: current.options?.listId,
         });
+        startMisskeyHealthCheck();
       }
     }
 
@@ -210,6 +246,7 @@ export function useStream() {
     misskeyPolling.stopPolling();
     mastodonStream.disconnect();
     blueskyPolling.stopPolling();
+    stopMisskeyHealthCheck();
   };
 
   return {

--- a/src/utils/misskeyStream.ts
+++ b/src/utils/misskeyStream.ts
@@ -54,7 +54,7 @@ export const useMisskeyStream = ({
   const shouldReconnect = ref(false);
   const reconnecting = ref(false);
   const webSocketId = ref<string | null>(null);
-  const subscriptionQueue: string[] = [];
+  const activeSubscriptions = new Set<string>();
   const url = ref<string>();
   const lastConnectOptions = ref<ConnectOptions | null>(null);
 
@@ -129,8 +129,8 @@ export const useMisskeyStream = ({
   });
 
   const handleServerConnected = () => {
-    if (!subscriptionQueue.length) return;
-    subscriptionQueue.forEach((postId) => {
+    if (!activeSubscriptions.size) return;
+    activeSubscriptions.forEach((postId) => {
       send(
         JSON.stringify({
           type: "subNote",
@@ -138,7 +138,6 @@ export const useMisskeyStream = ({
         }),
       );
     });
-    subscriptionQueue.length = 0;
   };
 
   const connect = ({ host, token, channel, channelId, antennaId, tag, listId, query }: ConnectOptions) => {
@@ -186,12 +185,14 @@ export const useMisskeyStream = ({
     shouldReconnect.value = false;
     reconnecting.value = false;
     lastConnectOptions.value = null;
+    activeSubscriptions.clear();
     close();
   };
 
   const state = computed(() => status.value);
 
   const subNote = (postId: string) => {
+    activeSubscriptions.add(postId);
     if (state.value === webSocketState.OPEN) {
       send(
         JSON.stringify({
@@ -199,12 +200,11 @@ export const useMisskeyStream = ({
           body: { id: postId },
         }),
       );
-    } else {
-      subscriptionQueue.push(postId);
     }
   };
 
   const unsubNote = (postId: string) => {
+    activeSubscriptions.delete(postId);
     if (state.value === webSocketState.OPEN) {
       send(
         JSON.stringify({
@@ -215,5 +215,5 @@ export const useMisskeyStream = ({
     }
   };
 
-  return { connect, reconnect, disconnect, state, subNote, unsubNote, subNoteQueue: subscriptionQueue };
+  return { connect, reconnect, disconnect, state, subNote, unsubNote };
 };

--- a/src/utils/misskeyStream.ts
+++ b/src/utils/misskeyStream.ts
@@ -141,16 +141,7 @@ export const useMisskeyStream = ({
     subscriptionQueue.length = 0;
   };
 
-  const connect = ({
-    host,
-    token,
-    channel,
-    channelId,
-    antennaId,
-    tag,
-    listId,
-    query,
-  }: ConnectOptions) => {
+  const connect = ({ host, token, channel, channelId, antennaId, tag, listId, query }: ConnectOptions) => {
     if (channel === "channel" && !channelId) return;
     if (channel === "antenna" && !antennaId) return;
     if (channel === "userList" && !listId) return;
@@ -170,6 +161,24 @@ export const useMisskeyStream = ({
       query,
     };
     url.value = buildMisskeyStreamUrl(host, token);
+    open();
+  };
+
+  /**
+   * Reconnect with the latest successful connect options.
+   */
+  const reconnect = (force = false) => {
+    const options = lastConnectOptions.value;
+    if (!options) return;
+    if (!force && (state.value === webSocketState.OPEN || state.value === webSocketState.CONNECTING)) {
+      return;
+    }
+
+    shouldReconnect.value = true;
+    reconnecting.value = true;
+    webSocketId.value = nanoid();
+    url.value = buildMisskeyStreamUrl(options.host, options.token);
+    close();
     open();
   };
 
@@ -206,5 +215,5 @@ export const useMisskeyStream = ({
     }
   };
 
-  return { connect, disconnect, state, subNote, unsubNote, subNoteQueue: subscriptionQueue };
+  return { connect, reconnect, disconnect, state, subNote, unsubNote, subNoteQueue: subscriptionQueue };
 };


### PR DESCRIPTION
Closes #304

## Summary
- keep the latest Misskey stream connect options so the client can reconnect on demand
- add a 30-second Misskey-only health check that reconnects when the WebSocket is no longer open/connecting
- trigger an immediate reconnect after resume and fetch diff posts on reconnect through the existing callback

## Verification
- timeout 180 pnpm typecheck