### PR TITLE
fix: show boosted Mastodon posts immediately

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -1,13 +1,4 @@
-import electron, {
-  app,
-  BrowserWindow,
-  dialog,
-  globalShortcut,
-  ipcMain,
-  Menu,
-  powerMonitor,
-  protocol,
-} from "electron";
+import electron, { app, BrowserWindow, dialog, globalShortcut, ipcMain, Menu, powerMonitor, protocol } from "electron";
 import path from "node:path";
 import { createMainWindow } from "./windows/mainWindow";
 import { createPostWindow } from "./windows/postWindow";
@@ -269,6 +260,9 @@ const start = async () => {
         mainWindow?.webContents.reload();
         break;
       case "main:reaction":
+        mainWindow?.webContents.send(event, data);
+        break;
+      case "timeline:add-post":
         mainWindow?.webContents.send(event, data);
         break;
       case "post:create":

--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -117,8 +117,11 @@ export function useStream() {
       await misskeyStore.createMyReaction(targetPost.id, data.reaction);
     });
 
-    window.ipc?.on("timeline:add-post", (_, data: { post: MastodonToot }) => {
+    window.ipc?.on("timeline:add-post", (_, data: { post: MastodonToot; timelineId?: string; userId?: string }) => {
       if (timelineStore.currentInstance?.type !== "mastodon") return;
+      if (!data.timelineId || !data.userId) return;
+      if (timelineStore.current?.id !== data.timelineId) return;
+      if (timelineStore.currentUser?.id !== data.userId) return;
       timelineStore.addNewPost(data.post);
       if (data.post.reblog) {
         timelineStore.updatePost(data.post.reblog as MastodonToot);

--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -116,6 +116,14 @@ export function useStream() {
 
       await misskeyStore.createMyReaction(targetPost.id, data.reaction);
     });
+
+    window.ipc?.on("timeline:add-post", (_, data: { post: MastodonToot }) => {
+      if (timelineStore.currentInstance?.type !== "mastodon") return;
+      timelineStore.addNewPost(data.post);
+      if (data.post.reblog) {
+        timelineStore.updatePost(data.post.reblog as MastodonToot);
+      }
+    });
   };
 
   // ストリーム初期化関数

--- a/src/pages/main/timeline.vue
+++ b/src/pages/main/timeline.vue
@@ -110,7 +110,12 @@ const onMastodonReply = (toot: MastodonTootType) => {
  * MastodonのBoost確認画面を開きます。
  */
 const onMastodonBoost = (toot: MastodonTootType) => {
-  ipcSend("post:repost", { post: toot, mode: "boost" });
+  ipcSend("post:repost", {
+    post: toot,
+    mode: "boost",
+    timelineId: timelineStore.current?.id,
+    userId: timelineStore.currentUser?.id,
+  });
 };
 
 const timelineContainer = ref<HTMLDivElement | null>(null);

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -516,6 +516,7 @@ const postToMastodon = async () => {
     });
     const res = handleApiResult(result, `${state.instance?.name ?? "Mastodon"} のブーストに失敗しました`);
     if (res) {
+      ipcSend("timeline:add-post", { post: res as MastodonTootType });
       ipcSend("post:close");
     }
     return;

--- a/src/pages/post/create.vue
+++ b/src/pages/post/create.vue
@@ -22,6 +22,8 @@ type PageProps = {
   emojis?: MisskeyEntities.EmojiSimple[];
   mode?: "boost" | "reply";
   replyToId?: string;
+  timelineId?: string;
+  userId?: string;
 };
 
 type UploadStatus = "ready" | "uploading" | "uploaded" | "failed";
@@ -516,7 +518,11 @@ const postToMastodon = async () => {
     });
     const res = handleApiResult(result, `${state.instance?.name ?? "Mastodon"} のブーストに失敗しました`);
     if (res) {
-      ipcSend("timeline:add-post", { post: res as MastodonTootType });
+      ipcSend("timeline:add-post", {
+        post: res as MastodonTootType,
+        timelineId: props.data.timelineId ?? state.timeline?.id,
+        userId: props.data.userId ?? state.user?.id,
+      });
       ipcSend("post:close");
     }
     return;


### PR DESCRIPTION
Closes #305

## Summary
- forward a post-window timeline insert event through the main process
- send the reblog response from the Mastodon boost flow back to the main window immediately
- append the returned reblog status to the active Mastodon timeline and refresh the original toot data when available

## Verification
- timeout 180 pnpm typecheck