### PR TITLE
feat: show timeline update countdown

### DIFF
--- a/src/components/TimelineHeader.vue
+++ b/src/components/TimelineHeader.vue
@@ -2,7 +2,7 @@
 import router from "@/router";
 import { useTimelineStore } from "@/store/timeline";
 import { ipcSend } from "@/utils/ipc";
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { Icon } from "@iconify/vue";
 import { useUsersStore } from "@/store/users";
 import { useInstanceStore } from "@/store/instance";
@@ -68,6 +68,50 @@ const currentEmojis = computed(() => {
   return timelineStore.currentInstance.misskey?.emojis || [];
 });
 
+const now = ref(Date.now());
+const nextUpdateAt = ref<number | null>(null);
+let countdownTimer: number | undefined;
+
+const shouldShowUpdateCountdown = computed(() => {
+  const type = timelineStore.currentInstance?.type;
+  const channel = timelineStore.current?.channel;
+  const interval = timelineStore.current?.updateInterval ?? 0;
+  if (!interval) return false;
+  if (type === "bluesky") return true;
+  if (type === "mastodon" && channel !== "mastodon:notifications") return true;
+  return false;
+});
+
+const syncCountdown = () => {
+  if (!shouldShowUpdateCountdown.value || !timelineStore.current?.updateInterval) {
+    nextUpdateAt.value = null;
+    return;
+  }
+
+  nextUpdateAt.value = Date.now() + timelineStore.current.updateInterval;
+};
+
+const tickCountdown = () => {
+  now.value = Date.now();
+  const interval = timelineStore.current?.updateInterval ?? 0;
+  if (!shouldShowUpdateCountdown.value || !interval || nextUpdateAt.value === null) {
+    return;
+  }
+
+  while (nextUpdateAt.value <= now.value) {
+    nextUpdateAt.value += interval;
+  }
+};
+
+const updateCountdownLabel = computed(() => {
+  if (!shouldShowUpdateCountdown.value || nextUpdateAt.value === null) return "";
+
+  const remainingSeconds = Math.max(0, Math.ceil((nextUpdateAt.value - now.value) / 1000));
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+});
+
 const toggleMenu = () => {
   isDetailVisible.value = !isDetailVisible.value;
 };
@@ -104,6 +148,32 @@ const getChannelLabel = (channel: MisskeyChannelName | MastodonChannelName | Blu
 
   return allChannelNameMap[channel] || channel;
 };
+
+watch(
+  () =>
+    [
+      timelineStore.current?.id,
+      timelineStore.current?.channel,
+      timelineStore.current?.updateInterval,
+      timelineStore.currentInstance?.type,
+    ] as const,
+  () => {
+    syncCountdown();
+    tickCountdown();
+  },
+  { immediate: true },
+);
+
+onMounted(() => {
+  countdownTimer = window.setInterval(() => {
+    tickCountdown();
+  }, 1000);
+});
+
+onBeforeUnmount(() => {
+  if (!countdownTimer) return;
+  window.clearInterval(countdownTimer);
+});
 </script>
 
 <template>
@@ -130,6 +200,9 @@ const getChannelLabel = (channel: MisskeyChannelName | MastodonChannelName | Blu
         />
         <ChannelIcon v-if="currentTimelineImages.channel" :channel="currentTimelineImages.channel" />
       </div>
+    </div>
+    <div class="update-countdown" v-if="updateCountdownLabel">
+      <span>次回 {{ updateCountdownLabel }}</span>
     </div>
     <div class="detail" v-if="isDetailVisible" ref="detailRef">
       <div class="action-group">
@@ -189,6 +262,15 @@ const getChannelLabel = (channel: MisskeyChannelName | MastodonChannelName | Blu
   background-color: var(--dote-background-color);
   border: 1px solid var(--dote-border-color);
   -webkit-app-region: drag;
+}
+.update-countdown {
+  position: absolute;
+  right: 12px;
+  color: var(--color-text-caption);
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+  -webkit-app-region: no-drag;
 }
 .timeline-images {
   display: inline-flex;

--- a/src/components/TimelineHeader.vue
+++ b/src/components/TimelineHeader.vue
@@ -107,9 +107,7 @@ const updateCountdownLabel = computed(() => {
   if (!shouldShowUpdateCountdown.value || nextUpdateAt.value === null) return "";
 
   const remainingSeconds = Math.max(0, Math.ceil((nextUpdateAt.value - now.value) / 1000));
-  const minutes = Math.floor(remainingSeconds / 60);
-  const seconds = remainingSeconds % 60;
-  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  return `${remainingSeconds}`;
 });
 
 const toggleMenu = () => {
@@ -202,7 +200,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
     <div class="update-countdown" v-if="updateCountdownLabel">
-      <span>次回 {{ updateCountdownLabel }}</span>
+      <span>{{ updateCountdownLabel }}</span>
     </div>
     <div class="detail" v-if="isDetailVisible" ref="detailRef">
       <div class="action-group">

--- a/src/composables/useStream.ts
+++ b/src/composables/useStream.ts
@@ -2,7 +2,7 @@ import { useStore } from "@/store";
 import { useTimelineStore } from "@/store/timeline";
 import { mastodonChannels } from "@/utils/mastodon";
 import { misskeyChannels } from "@/utils/misskey";
-import { useBlueskyPolling, useMisskeyPolling } from "@/utils/polling";
+import { useBlueskyPolling, useMastodonPolling, useMisskeyPolling } from "@/utils/polling";
 import { MisskeyStreamChannel, useMisskeyStream } from "@/utils/misskeyStream";
 import { BlueskyChannelName, MastodonChannelName, MisskeyChannelName } from "@shared/types/store";
 import { blueskyChannels } from "@/utils/bluesky";
@@ -59,6 +59,12 @@ export function useStream() {
   });
 
   const misskeyPolling = useMisskeyPolling({
+    poll: () => {
+      timelineStore.fetchDiffPosts();
+    },
+  });
+
+  const mastodonPolling = useMastodonPolling({
     poll: () => {
       timelineStore.fetchDiffPosts();
     },
@@ -127,6 +133,7 @@ export function useStream() {
     misskeyStream.disconnect();
     misskeyPolling.stopPolling();
     mastodonStream.disconnect();
+    mastodonPolling.stopPolling();
     blueskyPolling.stopPolling();
 
     if (mastodonChannels.includes(current.channel as MastodonChannelName)) {
@@ -142,6 +149,9 @@ export function useStream() {
         channel: current.channel as MastodonChannelName,
         token: timelineStore.currentUser.token,
       });
+      if (current.channel !== "mastodon:notifications") {
+        mastodonPolling.startPolling(timelineStore.current.updateInterval);
+      }
     }
 
     if (misskeyChannels.includes(current.channel as MisskeyChannelName)) {
@@ -209,6 +219,7 @@ export function useStream() {
     misskeyStream.disconnect();
     misskeyPolling.stopPolling();
     mastodonStream.disconnect();
+    mastodonPolling.stopPolling();
     blueskyPolling.stopPolling();
   };
 

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -38,6 +38,13 @@ export const useMisskeyPolling = ({ poll }: { poll: () => void }) => {
 };
 
 /**
+ * Mastodon用のポーリング機能
+ */
+export const useMastodonPolling = ({ poll }: { poll: () => void }) => {
+  return usePolling({ poll });
+};
+
+/**
  * Bluesky用のポーリング機能
  */
 export const useBlueskyPolling = ({ poll }: { poll: () => void }) => {


### PR DESCRIPTION
Closes #306

## Summary
- add a Mastodon polling helper and run it on the configured update interval as a periodic diff refresh backup
- keep the existing Bluesky polling behavior and surface the same interval as a countdown in the header
- show a small  indicator on the right side of the timeline header for Mastodon/Bluesky timelines

## Verification
- timeout 180 pnpm typecheck