### PR TITLE
[codex] Guard update install requests

### DIFF
--- a/main/autoupdate.ts
+++ b/main/autoupdate.ts
@@ -291,7 +291,8 @@ export const checkForAppUpdates = async (): Promise<AutoUpdateState> => {
   if (
     autoUpdateState.status === "available" ||
     autoUpdateState.status === "downloading" ||
-    autoUpdateState.status === "downloaded"
+    autoUpdateState.status === "downloaded" ||
+    autoUpdateState.status === "installing"
   ) {
     return autoUpdateState;
   }
@@ -326,10 +327,33 @@ export const checkForAppUpdates = async (): Promise<AutoUpdateState> => {
  * Restart the application and install the already-downloaded update.
  */
 export const installDownloadedUpdate = (): AutoUpdateState => {
+  if (autoUpdateState.status === "installing") {
+    return autoUpdateState;
+  }
+
   if (autoUpdateState.status !== "downloaded") {
     return autoUpdateState;
   }
 
-  autoUpdater.quitAndInstall();
-  return autoUpdateState;
+  const installingState = setAutoUpdateState({
+    status: "installing",
+    errorMessage: null,
+  });
+
+  try {
+    autoUpdater.quitAndInstall();
+  } catch (error) {
+    log.error("autoUpdater: install failed", error);
+    return setAutoUpdateState({
+      status: "error",
+      checkedAt: nowIsoString(),
+      errorMessage: toErrorMessage(error),
+      progressPercent: null,
+      bytesPerSecond: null,
+      transferredBytes: null,
+      totalBytes: null,
+    });
+  }
+
+  return installingState;
 };

--- a/shared/types/update.d.ts
+++ b/shared/types/update.d.ts
@@ -5,6 +5,7 @@ export type AutoUpdateStatus =
   | "not-available"
   | "downloading"
   | "downloaded"
+  | "installing"
   | "error"
   | "disabled";
 

--- a/src/components/Settings/ApplicationInformation.vue
+++ b/src/components/Settings/ApplicationInformation.vue
@@ -64,6 +64,7 @@ const statusLabel = computed(() => {
     "not-available": "最新です",
     downloading: "ダウンロード中",
     downloaded: "適用できます",
+    installing: "適用中",
     error: "エラー",
     disabled: "利用できません",
   };
@@ -105,7 +106,7 @@ const progressLabel = computed(() => {
 });
 
 const canCheckForUpdates = computed(() => {
-  return !["checking", "available", "downloading", "downloaded"].includes(autoUpdateState.value.status);
+  return !["checking", "available", "downloading", "downloaded", "installing"].includes(autoUpdateState.value.status);
 });
 
 const canInstallUpdate = computed(() => autoUpdateState.value.status === "downloaded");
@@ -256,6 +257,7 @@ onUnmounted(() => {
 
 .status-badge.is-checking,
 .status-badge.is-downloading,
+.status-badge.is-installing,
 .status-badge.is-available {
   color: var(--color-text-body);
 }


### PR DESCRIPTION
## Summary
- Add an `installing` auto-update state for restart/install requests.
- Move the updater into `installing` before calling `autoUpdater.quitAndInstall()`.
- Disable repeat update checks/install clicks while install is pending and show an `適用中` status in settings.

## Why
`quitAndInstall()` can return before the app fully exits, especially on macOS. Keeping the state as `downloaded` allowed duplicate install requests from the renderer or repeated IPC calls.

## Checks
- `pnpm run typecheck`
- `./node_modules/.bin/prettier --check main/autoupdate.ts shared/types/update.d.ts src/components/Settings/ApplicationInformation.vue`
- `git diff --check`